### PR TITLE
Fix: Resolve Vite/Rollup import alias error

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,0 @@
-export default {
-  server: {
-    hmr: {
-      clientPort: 443
-    }
-  }
-};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,5 +39,10 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src')
     }
+  },
+  server: {
+    hmr: {
+      clientPort: 443
+    }
   }
 })


### PR DESCRIPTION
The build process was failing with an error indicating that Rollup could not resolve the import alias "@" (e.g., "@/utils/apiErrorHandler") in src/main.tsx.

This issue was likely caused by the presence of both vite.config.js and vite.config.ts. Vite might have been defaulting to or getting confused by the minimal vite.config.js, which did not contain the necessary alias configurations.

The fix involves:
1. Merging the HMR settings from vite.config.js into vite.config.ts.
2. Removing vite.config.js to ensure vite.config.ts is the sole source of configuration for Vite.

This change ensures that Vite's build process correctly recognizes the path aliases defined in vite.config.ts, allowing Rollup to resolve module paths as intended.