### PR TITLE
Fix: Improve storage error handling and extension stability

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -34,7 +34,13 @@ async function askZionGPT(prompt) {
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'ask') {
-    askZionGPT(message.prompt).then(sendResponse);
+    askZionGPT(message.prompt).then(response => {
+      try {
+        sendResponse(response);
+      } catch (e) {
+        console.warn("Failed to send response to sender for 'ask' message. Channel likely closed.", e.message);
+      }
+    });
     return true;
   }
   if (message.type === 'post-job') {

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -1,49 +1,105 @@
+let isLocalStorageAvailable = true;
+const localStorageMemoryStore: { [key: string]: string } = {};
+
 export const safeStorage = {
   getItem: (key: string): string | null => {
+    if (!isLocalStorageAvailable) {
+      return localStorageMemoryStore[key] || null;
+    }
     try {
       return localStorage.getItem(key);
     } catch (e) {
-      console.warn('Storage access error:', e);
-      return null;
+      if (isLocalStorageAvailable) { // Only log once
+        console.warn('localStorage is not available. Falling back to in-memory storage for this session.', e);
+        isLocalStorageAvailable = false;
+      }
+      return localStorageMemoryStore[key] || null;
     }
   },
   setItem: (key: string, value: string) => {
+    if (!isLocalStorageAvailable) {
+      localStorageMemoryStore[key] = value;
+      return;
+    }
     try {
       localStorage.setItem(key, value);
     } catch (e) {
-      console.warn('Storage access error:', e);
+      if (isLocalStorageAvailable) { // Only log once
+        console.warn('localStorage is not available. Falling back to in-memory storage for this session.', e);
+        isLocalStorageAvailable = false;
+      }
+      localStorageMemoryStore[key] = value;
     }
   },
   removeItem: (key: string) => {
+    if (!isLocalStorageAvailable) {
+      delete localStorageMemoryStore[key];
+      return;
+    }
     try {
       localStorage.removeItem(key);
     } catch (e) {
-      console.warn('Storage access error:', e);
+      if (isLocalStorageAvailable) { // Only log once
+        console.warn('localStorage is not available. Falling back to in-memory storage for this session.', e);
+        isLocalStorageAvailable = false;
+      }
+      delete localStorageMemoryStore[key];
     }
+  },
+  get isAvailable(): boolean {
+    return isLocalStorageAvailable;
   }
 };
 
+let isSessionStorageAvailable = true;
+const sessionStorageMemoryStore: { [key: string]: string } = {};
+
 export const safeSessionStorage = {
   getItem: (key: string): string | null => {
+    if (!isSessionStorageAvailable) {
+      return sessionStorageMemoryStore[key] || null;
+    }
     try {
       return sessionStorage.getItem(key);
     } catch (e) {
-      console.warn('Storage access error:', e);
-      return null;
+      if (isSessionStorageAvailable) { // Only log once
+        console.warn('sessionStorage is not available. Falling back to in-memory storage for this session.', e);
+        isSessionStorageAvailable = false;
+      }
+      return sessionStorageMemoryStore[key] || null;
     }
   },
   setItem: (key: string, value: string) => {
+    if (!isSessionStorageAvailable) {
+      sessionStorageMemoryStore[key] = value;
+      return;
+    }
     try {
       sessionStorage.setItem(key, value);
     } catch (e) {
-      console.warn('Storage access error:', e);
+      if (isSessionStorageAvailable) { // Only log once
+        console.warn('sessionStorage is not available. Falling back to in-memory storage for this session.', e);
+        isSessionStorageAvailable = false;
+      }
+      sessionStorageMemoryStore[key] = value;
     }
   },
   removeItem: (key: string) => {
+    if (!isSessionStorageAvailable) {
+      delete sessionStorageMemoryStore[key];
+      return;
+    }
     try {
       sessionStorage.removeItem(key);
     } catch (e) {
-      console.warn('Storage access error:', e);
+      if (isSessionStorageAvailable) { // Only log once
+        console.warn('sessionStorage is not available. Falling back to in-memory storage for this session.', e);
+        isSessionStorageAvailable = false;
+      }
+      delete sessionStorageMemoryStore[key];
     }
+  },
+  get isAvailable(): boolean {
+    return isSessionStorageAvailable;
   }
 };


### PR DESCRIPTION
This commit addresses two main issues:
1.  Storage Access Errors:
    - Modified `src/utils/safeStorage.ts` to implement a robust in-memory fallback when `localStorage` or `sessionStorage` are unavailable (e.g., due to your browser privacy settings).
    - This prevents application crashes when storage access is denied and logs a warning.
    - Added an `isAvailable` getter to `safeStorage` and `safeSessionStorage` to allow other parts of the application to check for true persistence.
    - This change aims to mitigate errors like "Access to storage is not allowed from this context," including those reported by third-party scripts like LaunchDarkly that might be attempting to use `localStorage`.

2.  Chrome Extension Asynchronous Listener Error:
    - Refactored `extension/background.js` to handle potential errors in asynchronous message passing.
    - Specifically, the `sendResponse` call for the `askZionGPT` functionality is now wrapped in a `try...catch` block.
    - This prevents unhandled promise rejections if the message sender (e.g., the extension popup) is closed before a response can be sent, resolving errors like "A listener indicated an asynchronous response... but the message channel closed."

I recommend you perform manual testing to verify these fixes, especially under conditions where browser storage is restricted and by testing the Chrome extension's messaging robustness.