### PR TITLE
Add sample products and paginate marketplace

### DIFF
--- a/src/data/listingData.ts
+++ b/src/data/listingData.ts
@@ -130,6 +130,126 @@ export const MARKETPLACE_LISTINGS: ProductListing[] = [
     location: "Global",
     availability: "Immediate",
     aiScore: 94
+  },
+  {
+    id: "ai-storage-13",
+    title: "AI-Optimized Cloud Storage",
+    description: "Secure and high-speed cloud storage designed for AI workloads with automated backup and scalability.",
+    category: "Cloud Services",
+    price: 799,
+    currency: "$",
+    tags: ["Cloud Storage", "Backup", "Scalable"],
+    author: {
+      name: "CloudMatrix",
+      id: "cloudmatrix"
+    },
+    images: ["https://images.unsplash.com/photo-1518779578993-ec3579fee39f?auto=format&fit=crop&w=800&h=500"],
+    createdAt: "2024-03-18T10:00:00.000Z",
+    rating: 4.6,
+    reviewCount: 27,
+    location: "Global",
+    availability: "Immediate",
+    aiScore: 87
+  },
+  {
+    id: "ai-edge-14",
+    title: "Edge AI Development Kit",
+    description: "Compact development kit with built-in AI acceleration for prototyping edge computing applications.",
+    category: "Hardware",
+    price: 1299,
+    currency: "$",
+    tags: ["Edge Computing", "Dev Kit", "AI Accelerator"],
+    author: {
+      name: "EdgeWorks",
+      id: "edgeworks"
+    },
+    images: ["https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=800&h=500"],
+    createdAt: "2024-03-10T09:00:00.000Z",
+    rating: 4.7,
+    reviewCount: 15,
+    location: "Global",
+    availability: "1-2 Weeks",
+    aiScore: 90
+  },
+  {
+    id: "ai-labeling-15",
+    title: "Managed Data Labeling Service",
+    description: "Professional data labeling with quality assurance for training supervised machine learning models.",
+    category: "Services",
+    price: 1499,
+    currency: "$",
+    tags: ["Data Labeling", "Annotation", "Machine Learning"],
+    author: {
+      name: "LabelForce",
+      id: "labelforce"
+    },
+    images: ["https://images.unsplash.com/photo-1551836022-d5d88e9218df?auto=format&fit=crop&w=800&h=500"],
+    createdAt: "2024-03-08T11:45:00.000Z",
+    rating: 4.5,
+    reviewCount: 23,
+    location: "Europe",
+    availability: "2-3 Weeks",
+    aiScore: 85
+  },
+  {
+    id: "ai-security-16",
+    title: "AI Security Monitoring Suite",
+    description: "Real-time threat detection powered by AI with automated incident response for cloud and on-premise systems.",
+    category: "Security",
+    price: 2999,
+    currency: "$",
+    tags: ["Security", "Threat Detection", "Monitoring"],
+    author: {
+      name: "SecureAI",
+      id: "secureai"
+    },
+    images: ["https://images.unsplash.com/photo-1507679799987-c73779587ccf?auto=format&fit=crop&w=800&h=500"],
+    createdAt: "2024-03-02T08:40:00.000Z",
+    rating: 4.8,
+    reviewCount: 34,
+    location: "North America",
+    availability: "Immediate",
+    aiScore: 92
+  },
+  {
+    id: "ai-marketing-17",
+    title: "AI Marketing Automation Platform",
+    description: "Automate customer segmentation, campaign optimization, and analytics using machine learning.",
+    category: "Marketing",
+    price: 999,
+    currency: "$",
+    tags: ["Marketing", "Automation", "Analytics"],
+    author: {
+      name: "MarketMinds",
+      id: "marketminds"
+    },
+    images: ["https://images.unsplash.com/photo-1497493292307-31c376b6e479?auto=format&fit=crop&w=800&h=500"],
+    createdAt: "2024-03-14T12:00:00.000Z",
+    rating: 4.6,
+    reviewCount: 52,
+    location: "Global",
+    availability: "Immediate",
+    aiScore: 89
+  },
+  {
+    id: "ai-cloudgpu-18",
+    title: "Cloud GPU Rental Service",
+    description: "On-demand high-performance GPUs for training and inference, billed hourly with flexible plans.",
+    category: "Cloud Services",
+    price: 4.99,
+    currency: "$",
+    tags: ["GPU", "Cloud", "Rental"],
+    author: {
+      name: "GPUCloud",
+      id: "gpucloud"
+    },
+    images: ["https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=800&h=500"],
+    createdAt: "2024-03-20T07:50:00.000Z",
+    rating: 4.7,
+    reviewCount: 48,
+    location: "Global",
+    availability: "Immediate",
+    aiScore: 93
   }
 ];
 

--- a/src/data/marketplaceData.ts
+++ b/src/data/marketplaceData.ts
@@ -297,6 +297,126 @@ export const MARKETPLACE_LISTINGS: ProductListing[] = [
     featured: true,
     location: "North America",
     availability: "2-4 Weeks"
+  },
+  {
+    id: "ai-storage-13",
+    title: "AI-Optimized Cloud Storage",
+    description: "Secure and high-speed cloud storage designed for AI workloads with automated backup and scalability.",
+    category: "Cloud Services",
+    price: 799,
+    currency: "$",
+    tags: ["Cloud Storage", "Backup", "Scalable"],
+    author: {
+      name: "CloudMatrix",
+      id: "cloudmatrix"
+    },
+    images: ["https://images.unsplash.com/photo-1518779578993-ec3579fee39f?auto=format&fit=crop&w=800&h=500"],
+    createdAt: "2024-03-18T10:00:00.000Z",
+    rating: 4.6,
+    reviewCount: 27,
+    location: "Global",
+    availability: "Immediate",
+    aiScore: 87
+  },
+  {
+    id: "ai-edge-14",
+    title: "Edge AI Development Kit",
+    description: "Compact development kit with built-in AI acceleration for prototyping edge computing applications.",
+    category: "Hardware",
+    price: 1299,
+    currency: "$",
+    tags: ["Edge Computing", "Dev Kit", "AI Accelerator"],
+    author: {
+      name: "EdgeWorks",
+      id: "edgeworks"
+    },
+    images: ["https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=800&h=500"],
+    createdAt: "2024-03-10T09:00:00.000Z",
+    rating: 4.7,
+    reviewCount: 15,
+    location: "Global",
+    availability: "1-2 Weeks",
+    aiScore: 90
+  },
+  {
+    id: "ai-labeling-15",
+    title: "Managed Data Labeling Service",
+    description: "Professional data labeling with quality assurance for training supervised machine learning models.",
+    category: "Services",
+    price: 1499,
+    currency: "$",
+    tags: ["Data Labeling", "Annotation", "Machine Learning"],
+    author: {
+      name: "LabelForce",
+      id: "labelforce"
+    },
+    images: ["https://images.unsplash.com/photo-1551836022-d5d88e9218df?auto=format&fit=crop&w=800&h=500"],
+    createdAt: "2024-03-08T11:45:00.000Z",
+    rating: 4.5,
+    reviewCount: 23,
+    location: "Europe",
+    availability: "2-3 Weeks",
+    aiScore: 85
+  },
+  {
+    id: "ai-security-16",
+    title: "AI Security Monitoring Suite",
+    description: "Real-time threat detection powered by AI with automated incident response for cloud and on-premise systems.",
+    category: "Security",
+    price: 2999,
+    currency: "$",
+    tags: ["Security", "Threat Detection", "Monitoring"],
+    author: {
+      name: "SecureAI",
+      id: "secureai"
+    },
+    images: ["https://images.unsplash.com/photo-1507679799987-c73779587ccf?auto=format&fit=crop&w=800&h=500"],
+    createdAt: "2024-03-02T08:40:00.000Z",
+    rating: 4.8,
+    reviewCount: 34,
+    location: "North America",
+    availability: "Immediate",
+    aiScore: 92
+  },
+  {
+    id: "ai-marketing-17",
+    title: "AI Marketing Automation Platform",
+    description: "Automate customer segmentation, campaign optimization, and analytics using machine learning.",
+    category: "Marketing",
+    price: 999,
+    currency: "$",
+    tags: ["Marketing", "Automation", "Analytics"],
+    author: {
+      name: "MarketMinds",
+      id: "marketminds"
+    },
+    images: ["https://images.unsplash.com/photo-1497493292307-31c376b6e479?auto=format&fit=crop&w=800&h=500"],
+    createdAt: "2024-03-14T12:00:00.000Z",
+    rating: 4.6,
+    reviewCount: 52,
+    location: "Global",
+    availability: "Immediate",
+    aiScore: 89
+  },
+  {
+    id: "ai-cloudgpu-18",
+    title: "Cloud GPU Rental Service",
+    description: "On-demand high-performance GPUs for training and inference, billed hourly with flexible plans.",
+    category: "Cloud Services",
+    price: 4.99,
+    currency: "$",
+    tags: ["GPU", "Cloud", "Rental"],
+    author: {
+      name: "GPUCloud",
+      id: "gpucloud"
+    },
+    images: ["https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=800&h=500"],
+    createdAt: "2024-03-20T07:50:00.000Z",
+    rating: 4.7,
+    reviewCount: 48,
+    location: "Global",
+    availability: "Immediate",
+    aiScore: 93
   }
 ];
 

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -15,6 +15,14 @@ import { useNavigate } from "react-router-dom";
 import { SearchSuggestion } from "@/types/search";
 import styles from './Marketplace.module.css';
 import { useViewMode } from '@/context/ViewModeContext';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination';
 
 interface ProductContainerProps {
   listings: ProductListing[];
@@ -61,6 +69,8 @@ export default function Marketplace() {
   const [listings, setListings] = useState(MARKETPLACE_LISTINGS);
   const [isLoading, setIsLoading] = useState(false);
   const { viewMode, setViewMode } = useViewMode();
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 10;
 
   // Automatically append a new listing every 2 minutes
   useEffect(() => {
@@ -75,6 +85,7 @@ export default function Marketplace() {
 
   useEffect(() => {
     setIsLoading(true);
+    setCurrentPage(1);
     const timeout = setTimeout(() => setIsLoading(false), 300);
     return () => clearTimeout(timeout);
   }, [searchQuery, selectedProductTypes, selectedLocations, selectedAvailability, selectedRating]);
@@ -110,6 +121,12 @@ export default function Marketplace() {
     
     return true;
   });
+
+  const totalPages = Math.ceil(filteredListings.length / itemsPerPage);
+  const paginatedListings = filteredListings.slice(
+    (currentPage - 1) * itemsPerPage,
+    currentPage * itemsPerPage
+  );
   
   const handleFilterChange = (filterType: string, value: string) => {
     console.log(`Filter changed: ${filterType} = ${value}`);
@@ -259,9 +276,9 @@ export default function Marketplace() {
               </div>
             ) : filteredListings.length > 0 ? (
               viewMode === 'grid' ? (
-                <ProductGrid listings={filteredListings} onRequestQuote={handleRequestQuote} />
+                <ProductGrid listings={paginatedListings} onRequestQuote={handleRequestQuote} />
               ) : (
-                <ProductList listings={filteredListings} onRequestQuote={handleRequestQuote} />
+                <ProductList listings={paginatedListings} onRequestQuote={handleRequestQuote} />
               )
             ) : (
               <div className="col-span-2 text-center py-16 bg-zion-blue-dark border border-zion-blue-light rounded-lg">
@@ -275,6 +292,46 @@ export default function Marketplace() {
                 >
                   Clear Filters
                 </Button>
+              </div>
+            )}
+            {totalPages > 1 && (
+              <div className="mt-6">
+                <Pagination className="justify-center">
+                  <PaginationContent>
+                    <PaginationItem>
+                      <PaginationPrevious
+                        href="#"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setCurrentPage(Math.max(1, currentPage - 1));
+                        }}
+                      />
+                    </PaginationItem>
+                    {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+                      <PaginationItem key={page}>
+                        <PaginationLink
+                          href="#"
+                          isActive={page === currentPage}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            setCurrentPage(page);
+                          }}
+                        >
+                          {page}
+                        </PaginationLink>
+                      </PaginationItem>
+                    ))}
+                    <PaginationItem>
+                      <PaginationNext
+                        href="#"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setCurrentPage(Math.min(totalPages, currentPage + 1));
+                        }}
+                      />
+                    </PaginationItem>
+                  </PaginationContent>
+                </Pagination>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- expand marketplace data with additional sample listings
- mirror new products in listing data
- add pagination controls to marketplace page

## Testing
- `./setup.sh npm` *(fails: ENOENT for dependencies)*
- `npm run test` *(fails: vitest not found)*