### PR TITLE
Fix duplicated header on sitemap page

### DIFF
--- a/src/pages/Sitemap.tsx
+++ b/src/pages/Sitemap.tsx
@@ -1,5 +1,3 @@
-import { Header } from "@/components/Header";
-import { Footer } from "@/components/Footer";
 import { SEO } from "@/components/SEO";
 import { completeSitemap } from "@/config/sitemap";
 import { Link } from "react-router-dom";
@@ -13,7 +11,6 @@ export default function Sitemap() {
         keywords="sitemap, navigation"
         canonical="https://app.ziontechgroup.com/sitemap"
       />
-      <Header />
       <main className="min-h-screen bg-zion-blue pt-24 pb-20">
         <div className="container mx-auto px-4">
           <h1 className="text-3xl font-bold mb-8">Sitemap</h1>
@@ -28,7 +25,6 @@ export default function Sitemap() {
           </ul>
         </div>
       </main>
-      <Footer />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- remove explicit header and footer from sitemap page

## Testing
- `npm run test` *(fails: vitest not found)*