### PR TITLE
Fix translation service fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Supabase edge function that provides whitelabel settings failed. Confirm that
 environment and that you have network connectivity. The tenant hook will retry
 a few times before giving up.
 
+### Translation Service
+
+Automatic translations rely on OpenAI. Set `VITE_OPENAI_API_KEY` (or
+`NEXT_PUBLIC_OPENAI_API_KEY`) to allow the client to contact the API directly
+when the Supabase function is unavailable.
+
 ## Testing
 
 Run unit tests with:

--- a/src/hooks/useTranslationService.ts
+++ b/src/hooks/useTranslationService.ts
@@ -1,6 +1,11 @@
 
 import { useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+
+const openAiKey =
+  import.meta.env.VITE_OPENAI_API_KEY ||
+  (import.meta.env as any).NEXT_PUBLIC_OPENAI_API_KEY ||
+  process.env.OPENAI_API_KEY;
 import { useLanguage, SupportedLanguage } from '@/context/LanguageContext';
 
 type ContentType = 'job' | 'profile' | 'service' | 'general';
@@ -21,8 +26,56 @@ export function useTranslationService() {
     targetLanguages: SupportedLanguage[] = ['en', 'es', 'pt', 'ar']
   ): Promise<TranslationResponse> => {
     setIsTranslating(true);
-    
+
     try {
+      if (openAiKey) {
+        const systemPrompt =
+          contentType === 'job'
+            ? 'You are a professional translator specializing in job descriptions. Translate the content accurately while maintaining the professional tone and technical terminology.'
+            : contentType === 'profile'
+              ? 'You are a professional translator specializing in professional profiles. Translate the content accurately while maintaining the professional tone and highlighting skills appropriately.'
+              : 'You are a professional translator. Translate the content accurately while maintaining the original meaning, tone, and format.';
+
+        const translations: Record<SupportedLanguage, string> = {} as Record<SupportedLanguage, string>;
+
+        for (const targetLang of targetLanguages) {
+          if (targetLang === sourceLanguage) {
+            translations[targetLang] = content;
+            continue;
+          }
+
+          const response = await fetch('https://api.openai.com/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${openAiKey}`,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              model: 'gpt-4o',
+              messages: [
+                { role: 'system', content: systemPrompt },
+                {
+                  role: 'user',
+                  content: `Translate the following ${contentType || 'content'} from ${sourceLanguage} to ${targetLang}:\n\n${content}\n\nOnly provide the translated text, no explanations or additional comments.`
+                }
+              ],
+              temperature: 0.3
+            })
+          });
+
+          if (!response.ok) {
+            const errorData = await response.json();
+            throw new Error(`OpenAI API error: ${JSON.stringify(errorData)}`);
+          }
+
+          const data = await response.json();
+          translations[targetLang] = data.choices[0].message.content.trim();
+        }
+
+        setIsTranslating(false);
+        return { translations };
+      }
+
       const { data, error } = await supabase.functions.invoke('translate-content', {
         body: {
           content,


### PR DESCRIPTION
## Summary
- add client-side OpenAI fallback in translation hook when Supabase function fails
- document `VITE_OPENAI_API_KEY` env var for translations

## Testing
- `npm test` *(fails: vitest not found)*