### PR TITLE
Fix talent detail page 404 handling

### DIFF
--- a/pages/talent/[id].tsx
+++ b/pages/talent/[id].tsx
@@ -1,71 +1,36 @@
-import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { ProfileLoadingState } from '@/components/profile/ProfileLoadingState';
-import type { TalentProfile as TalentProfileType } from '@/types/talent';
-import { ProfileErrorState } from '@/components/profile/ProfileErrorState';
+import React from 'react';
+import type { GetStaticPaths, GetStaticProps } from 'next';
+import { TALENT_PROFILES } from '@/data/talentData';
+import type { TalentProfile } from '@/types/talent';
+import TalentDetails from '@/components/talent/TalentDetails';
+import NotFound from '@/components/NotFound';
 
-interface TalentProfileWithSocial extends TalentProfileType {
-  social?: Record<string, string>;
+interface TalentPageProps {
+  talent: TalentProfile | null;
 }
 
-const TalentProfilePage: React.FC = () => {
-  const { id } = useParams() as { id?: string };
-  const [profile, setProfile] = useState<TalentProfileWithSocial | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+const TalentPage: React.FC<TalentPageProps> = ({ talent }) => {
+  if (!talent) {
+    return <NotFound />;
+  }
 
-  useEffect(() => {
-    const fetchProfile = async () => {
-      if (!id) return;
-      setLoading(true);
-      setError(null);
-      try {
-        const res = await fetch(`/api/talent/${id}`);
-        if (res.status === 404) {
-          setError('Talent not found');
-          setProfile(null);
-          return;
-        }
-        if (!res.ok) throw new Error('Failed to load profile');
-        const data = await res.json();
-        setProfile(data.profile);
-      } catch (err) {
-        setError('Talent not found');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    if (id) {
-      fetchProfile();
-    }
-  }, [id]);
-
-  if (loading) return <ProfileLoadingState />;
-  if (error || !profile) return <ProfileErrorState error={error} />;
-
-  return (
-    <main className="min-h-screen bg-zion-blue py-8 text-white">
-      <div className="container mx-auto px-4 space-y-4">
-        <h1 className="text-3xl font-bold" data-testid="profile-name">
-          {profile.full_name}
-        </h1>
-        {profile.skills && profile.skills.length > 0 && (
-          <div>
-            <h2 className="font-semibold">Skills</h2>
-            <ul className="list-disc ml-5">
-              {profile.skills.map(skill => (
-                <li key={skill}>{skill}</li>
-              ))}
-            </ul>
-          </div>
-        )}
-        {profile.availability_type && (
-          <p>Availability: {profile.availability_type}</p>
-        )}
-      </div>
-    </main>
-  );
+  return <TalentDetails talent={talent} />;
 };
 
-export default TalentProfilePage;
+export const getStaticPaths: GetStaticPaths = async () => {
+  const paths = TALENT_PROFILES.map((t) => ({ params: { id: t.id } }));
+  return { paths, fallback: 'blocking' };
+};
+
+export const getStaticProps: GetStaticProps<TalentPageProps> = async ({ params }) => {
+  const id = params?.id as string;
+  const talent = TALENT_PROFILES.find((t) => t.id === id) || null;
+
+  if (!talent) {
+    return { notFound: true };
+  }
+
+  return { props: { talent } };
+};
+
+export default TalentPage;

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const NotFound: React.FC = () => (
+  <div className="flex flex-1 items-center justify-center bg-gray-100">
+    <div className="text-center p-6">
+      <h1 className="text-4xl font-bold mb-4 text-gray-800">404</h1>
+      <p className="text-xl text-gray-700 mb-4">Oops! Page not found</p>
+      <a
+        href="/"
+        className="text-blue-600 hover:text-blue-800 underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
+      >
+        Return to Home
+      </a>
+    </div>
+  </div>
+);
+
+export default NotFound;

--- a/src/components/talent/TalentDetails.tsx
+++ b/src/components/talent/TalentDetails.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { TalentProfile } from '@/types/talent';
+import { Button } from '@/components/ui/button';
+
+interface TalentDetailsProps {
+  talent: TalentProfile;
+}
+
+const TalentDetails: React.FC<TalentDetailsProps> = ({ talent }) => (
+  <main className="min-h-screen bg-zion-blue py-8 text-white" data-testid="talent-details">
+    <div className="container mx-auto px-4 space-y-6">
+      <h1 className="text-3xl font-bold">{talent.full_name}</h1>
+
+      {talent.bio && <p>{talent.bio}</p>}
+
+      {talent.key_projects && talent.key_projects.length > 0 && (
+        <section>
+          <h2 className="text-xl font-semibold mb-2">Portfolio</h2>
+          <ul className="space-y-2">
+            {talent.key_projects.map((proj, i) => (
+              <li key={i} className="border-b border-zion-purple/20 pb-2">
+                <h3 className="font-medium">{proj.title}</h3>
+                <p className="text-sm text-zion-slate">{proj.description}</p>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <Button className="bg-zion-purple text-white">Hire</Button>
+    </div>
+  </main>
+);
+
+export default TalentDetails;

--- a/tests/TalentNotFound.test.tsx
+++ b/tests/TalentNotFound.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import NotFound from '@/components/NotFound';
+import { getStaticProps } from '@/pages/talent/[id]';
+
+test('unknown talent id shows NotFound page', async () => {
+  const result = await getStaticProps({ params: { id: 'unknown-id' } } as any);
+  let show404 = false;
+
+  if ('notFound' in result && result.notFound) {
+    show404 = true;
+    render(<NotFound />);
+  }
+
+  expect(show404).toBe(true);
+  expect(screen.getByText(/oops! page not found/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- handle `/talent/[id]` using Next.js data fetching
- show a NotFound component for unknown talents
- add simple `TalentDetails` display component
- test that `getStaticProps` returns 404 for unknown talent

## Testing
- `npm run test` *(fails: vitest not found)*