### PR TITLE
Add basic cart and checkout flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-trick
 ## Integrations
 
 See [docs/Integrations.md](docs/Integrations.md) for information on the Zion Assistant browser extension and Slack bot.
+Payment environment variables are documented in [docs/Payments.md](docs/Payments.md).
 
 ## Troubleshooting
 

--- a/api/create-payment-intent.js
+++ b/api/create-payment-intent.js
@@ -1,0 +1,34 @@
+import Stripe from 'stripe';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    res.setHeader('Allow', 'POST');
+    res.end('Method Not Allowed');
+    return;
+  }
+
+  const { amount } = req.body || {};
+  if (typeof amount !== 'number') {
+    res.statusCode = 400;
+    res.json({ error: 'Invalid amount' });
+    return;
+  }
+
+  try {
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+      apiVersion: '2023-10-16',
+    });
+    const intent = await stripe.paymentIntents.create({
+      amount: Math.round(amount * 100),
+      currency: 'usd',
+      automatic_payment_methods: { enabled: true },
+    });
+    res.statusCode = 200;
+    res.json({ clientSecret: intent.client_secret, id: intent.id });
+  } catch (err) {
+    console.error('Create payment intent error:', err);
+    res.statusCode = 500;
+    res.json({ error: err.message });
+  }
+}

--- a/docs/Payments.md
+++ b/docs/Payments.md
@@ -1,0 +1,9 @@
+# Stripe Test Payments
+
+The demo checkout flow uses Stripe in test mode. Configure these environment variables before running the app:
+
+- `NEXT_PUBLIC_STRIPE_TEST_KEY` – publishable test key loaded by the client.
+- `STRIPE_SECRET_KEY` – secret API key used by `/api/create-payment-intent`.
+- `VITE_STRIPE_PUBLISHABLE_KEY` – optional publishable key for production builds.
+
+Set them in `.env` or your hosting provider's environment configuration.

--- a/pages/cart/index.tsx
+++ b/pages/cart/index.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../src/pages/Cart';

--- a/pages/checkout/index.tsx
+++ b/pages/checkout/index.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../src/pages/Checkout';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,8 @@ import OpenAppRedirect from './pages/OpenAppRedirect';
 import ContactPage from './pages/Contact';
 import ZionHireAI from './pages/ZionHireAI';
 import RequestQuotePage from './pages/RequestQuote';
+import CartPage from './pages/Cart';
+import CheckoutPage from './pages/Checkout';
 
 const baseRoutes = [
   { path: '/', element: <Home /> },
@@ -73,6 +75,8 @@ const baseRoutes = [
   { path: '/request-quote', element: <RequestQuotePage /> },
   { path: '/blog', element: <Blog /> },
   { path: '/blog/:slug', element: <BlogPost /> },
+  { path: '/cart', element: <CartPage /> },
+  { path: '/checkout', element: <CheckoutPage /> },
 ];
 
 const App = () => {

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import { safeStorage } from '@/utils/safeStorage';
+import { Button } from '@/components/ui/button';
+import { useNavigate } from 'react-router-dom';
+
+interface CartItem {
+  id: string;
+  name: string;
+  price: number;
+  quantity: number;
+}
+
+export default function CartPage() {
+  const navigate = useNavigate();
+  const [items, setItems] = useState<CartItem[]>([]);
+
+  useEffect(() => {
+    const stored = safeStorage.getItem('cart');
+    if (stored) {
+      try {
+        setItems(JSON.parse(stored) as CartItem[]);
+      } catch {
+        setItems([]);
+      }
+    }
+  }, []);
+
+  const updateQuantity = (id: string, qty: number) => {
+    setItems(prev => {
+      const updated = prev.map(i => i.id === id ? { ...i, quantity: qty } : i);
+      safeStorage.setItem('cart', JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  const removeItem = (id: string) => {
+    setItems(prev => {
+      const updated = prev.filter(i => i.id !== id);
+      safeStorage.setItem('cart', JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  const subtotal = items.reduce((sum, i) => sum + i.price * i.quantity, 0);
+
+  if (items.length === 0) {
+    return (
+      <div className="container py-10 text-center">
+        <p>Your cart is empty.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container max-w-2xl py-10">
+      <h1 className="text-3xl font-bold mb-6">Shopping Cart</h1>
+      <ul className="space-y-4">
+        {items.map(item => (
+          <li key={item.id} className="flex justify-between items-center">
+            <div>
+              <p className="font-medium">{item.name}</p>
+              <p className="text-sm text-muted-foreground">${item.price.toFixed(2)}</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                min={1}
+                value={item.quantity}
+                onChange={e => updateQuantity(item.id, parseInt(e.target.value || '1', 10))}
+                className="w-16 bg-transparent border border-input rounded p-1 text-center"
+              />
+              <Button variant="outline" size="sm" onClick={() => removeItem(item.id)}>
+                Remove
+              </Button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <div className="flex justify-between mt-6 font-semibold">
+        <span>Subtotal</span>
+        <span>${subtotal.toFixed(2)}</span>
+      </div>
+      <Button className="mt-4 w-full" onClick={() => navigate('/checkout')}>
+        Checkout
+      </Button>
+    </div>
+  );
+}

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1,8 +1,18 @@
 import React, { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { safeStorage } from '@/utils/safeStorage';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { useNavigate } from 'react-router-dom';
 import { getStripe } from '@/utils/getStripe';
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form';
 
 interface CartItem {
   id: string;
@@ -11,72 +21,120 @@ interface CartItem {
   quantity: number;
 }
 
-export default function Checkout() {
+interface CheckoutForm {
+  name: string;
+  email: string;
+  address: string;
+  city: string;
+  country: string;
+}
+
+export default function CheckoutPage() {
   const navigate = useNavigate();
   const [items, setItems] = useState<CartItem[]>([]);
+  const form = useForm<CheckoutForm>({ defaultValues: { name: '', email: '', address: '', city: '', country: '' } });
 
   useEffect(() => {
     const stored = safeStorage.getItem('cart');
     if (stored) {
       try {
-        const parsed = JSON.parse(stored) as CartItem[];
-        if (parsed.length > 0) {
-          setItems(parsed);
-          return;
-        }
+        setItems(JSON.parse(stored) as CartItem[]);
       } catch {
-        // ignore parsing errors
+        setItems([]);
       }
     }
-    // Provide mock data if cart empty
-    setItems([
-      {
-        id: 'prod_mock',
-        name: 'Test Item',
-        price: 25,
-        quantity: 1,
-      },
-    ]);
   }, []);
 
-  const handleCheckout = async () => {
-    const product = items[0];
+  const subtotal = items.reduce((sum, i) => sum + i.price * i.quantity, 0);
+
+  const onSubmit = async (data: CheckoutForm) => {
     try {
-      const response = await fetch('/api/checkout_sessions', {
+      const res = await fetch('/api/create-payment-intent', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ productId: product.id }),
+        body: JSON.stringify({ amount: subtotal }),
       });
-      const { sessionId } = await response.json();
+      const result = await res.json();
+      if (!res.ok) throw new Error(result.error || 'Failed');
       const stripe = await getStripe();
-      if (stripe && sessionId) {
-        await stripe.redirectToCheckout({ sessionId });
+      if (stripe && result.clientSecret) {
+        const payment = await stripe.confirmCardPayment(result.clientSecret, {
+          payment_method: {
+            card: { token: 'tok_visa' },
+            billing_details: { name: data.name, email: data.email },
+          },
+        });
+        if (payment.error) throw payment.error;
+        safeStorage.removeItem('cart');
+        navigate(`/orders/${result.id}`);
       }
     } catch (err) {
-      console.error('Checkout error', err);
+      console.error('Payment failed', err);
     }
   };
 
-  const total = items.reduce((sum, i) => sum + i.price * i.quantity, 0);
-
   return (
-    <div className="min-h-screen bg-zion-blue p-6">
-      <div className="max-w-xl mx-auto bg-zion-blue-dark rounded-lg p-6 text-white space-y-6">
-        <h1 className="text-2xl font-bold">Checkout</h1>
-        <ul className="space-y-2">
-          {items.map(item => (
-            <li key={item.id} className="flex justify-between">
-              <span>{item.name} x {item.quantity}</span>
-              <span>${(item.price * item.quantity).toFixed(2)}</span>
-            </li>
-          ))}
-        </ul>
-        <div className="flex justify-between font-semibold">
-          <span>Total</span>
-          <span>${total.toFixed(2)}</span>
-        </div>
-        <Button className="w-full" onClick={handleCheckout}>Buy Now</Button>
-        <Button variant="outline" className="w-full" onClick={() => navigate(-1)}>Back</Button>
+    <div className="container max-w-2xl py-10">
+      <h1 className="text-3xl font-bold mb-6">Checkout</h1>
+      <div className="grid gap-6">
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField name="name" control={form.control} render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )} />
+            <FormField name="email" control={form.control} render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input type="email" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )} />
+            <FormField name="address" control={form.control} render={({ field }) => (
+              <FormItem>
+                <FormLabel>Address</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )} />
+            <FormField name="city" control={form.control} render={({ field }) => (
+              <FormItem>
+                <FormLabel>City</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )} />
+            <FormField name="country" control={form.control} render={({ field }) => (
+              <FormItem>
+                <FormLabel>Country</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )} />
+            <div className="border-t pt-4">
+              <div className="flex justify-between font-semibold mb-4">
+                <span>Subtotal</span>
+                <span>${subtotal.toFixed(2)}</span>
+              </div>
+              <Button className="w-full" type="submit">
+                Pay with Stripe (test)
+              </Button>
+            </div>
+          </form>
+        </Form>
       </div>
     </div>
   );

--- a/src/pages/EquipmentDetail.tsx
+++ b/src/pages/EquipmentDetail.tsx
@@ -9,6 +9,7 @@ import { ShoppingCart, Star, Truck, Shield, RotateCcw, Clock } from "lucide-reac
 import { toast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { getStripe } from "@/utils/getStripe";
+import { safeStorage } from '@/utils/safeStorage';
 
 interface EquipmentSpecification {
   name: string;
@@ -176,9 +177,16 @@ export default function EquipmentDetail() {
 
   const handleAddToCart = () => {
     setIsAdding(true);
-    
-    // Simulate API call
+
     setTimeout(() => {
+      const stored = safeStorage.getItem('cart');
+      let cart: { id: string; name: string; price: number; quantity: number }[] = [];
+      if (stored) {
+        try { cart = JSON.parse(stored); } catch { /* ignore */ }
+      }
+      const existing = cart.find(i => i.id === equipment.id);
+      if (existing) existing.quantity += quantity; else cart.push({ id: equipment.id, name: equipment.name, price: equipment.price, quantity });
+      safeStorage.setItem('cart', JSON.stringify(cart));
       setIsAdding(false);
       toast({
         title: "Added to cart",


### PR DESCRIPTION
## Summary
- implement Cart and Checkout pages
- store cart items from equipment detail
- integrate new API route `/api/create-payment-intent`
- document Stripe environment variables
- expose Cart and Checkout routes

## Testing
- `npm run test` *(fails: vitest not found)*