### PR TITLE
Add cart context and hook into new products listing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,8 @@ import OpenAppRedirect from './pages/OpenAppRedirect';
 import ContactPage from './pages/Contact';
 import ZionHireAI from './pages/ZionHireAI';
 import RequestQuotePage from './pages/RequestQuote';
+import Checkout from './pages/Checkout';
+import ProductPage from './pages/ProductPage';
 
 const baseRoutes = [
   { path: '/', element: <Home /> },
@@ -61,6 +63,7 @@ const baseRoutes = [
   { path: '/equipment', element: <EquipmentPage /> },
   { path: '/equipment/:id', element: <EquipmentDetail /> },
   { path: '/new-products', element: <NewProductsPage /> },
+  { path: '/product/:id', element: <ProductPage /> },
   { path: '/analytics', element: <Analytics /> },
   { path: '/mobile-launch', element: <MobileLaunchPage /> },
   { path: '/open-app', element: <OpenAppRedirect /> },
@@ -71,6 +74,7 @@ const baseRoutes = [
   { path: '/zion-hire-ai', element: <ZionHireAI /> },
   { path: '/hire-ai', element: <ZionHireAI /> },
   { path: '/request-quote', element: <RequestQuotePage /> },
+  { path: '/cart', element: <Checkout /> },
   { path: '/blog', element: <Blog /> },
   { path: '/blog/:slug', element: <BlogPost /> },
 ];

--- a/src/components/header/MobileBottomNav.tsx
+++ b/src/components/header/MobileBottomNav.tsx
@@ -1,7 +1,8 @@
 
 import React from "react";
 import { Link, useLocation } from "react-router-dom";
-import { Home, Search, BriefcaseIcon, MessageSquare, User, MessageCircle } from "lucide-react";
+import { Home, Search, BriefcaseIcon, MessageSquare, User, MessageCircle, ShoppingCart } from "lucide-react";
+import { useCart } from "@/context/CartContext";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/useAuth";
 
@@ -13,6 +14,8 @@ export function MobileBottomNav({ unreadCount = 0 }: MobileBottomNavProps) {
   const location = useLocation();
   const { user } = useAuth();
   const isAuthenticated = !!user;
+  const { items } = useCart();
+  const cartCount = items.reduce((sum, i) => sum + i.quantity, 0);
 
   const navItems = [
     {
@@ -40,6 +43,13 @@ export function MobileBottomNav({ unreadCount = 0 }: MobileBottomNavProps) {
       matches: (path: string) => path.startsWith("/messages") || path.startsWith("/inbox"),
       badge: unreadCount,
       authRequired: true
+    },
+    {
+      name: "Cart",
+      href: "/cart",
+      icon: ShoppingCart,
+      matches: (path: string) => path.startsWith("/cart"),
+      badge: cartCount
     },
     {
       name: "Dashboard",

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -1,0 +1,66 @@
+import React, { createContext, useContext, useReducer, useEffect } from 'react';
+import { CartContextType, CartItem, CartAction } from '@/types/cart';
+import { safeStorage } from '@/utils/safeStorage';
+
+interface CartState { items: CartItem[]; }
+
+const initialState: CartState = { items: [] };
+
+function cartReducer(state: CartState, action: CartAction): CartState {
+  switch (action.type) {
+    case 'ADD_ITEM': {
+      const existing = state.items.find(i => i.id === action.payload.id);
+      let items;
+      if (existing) {
+        items = state.items.map(i =>
+          i.id === action.payload.id
+            ? { ...i, quantity: i.quantity + action.payload.quantity }
+            : i
+        );
+      } else {
+        items = [...state.items, action.payload];
+      }
+      return { items };
+    }
+    case 'REMOVE_ITEM':
+      return { items: state.items.filter(i => i.id !== action.payload) };
+    case 'CLEAR_CART':
+      return { items: [] };
+    default:
+      return state;
+  }
+}
+
+const CartContext = createContext<CartContextType | undefined>(undefined);
+
+export function useCart(): CartContextType {
+  const ctx = useContext(CartContext) as CartContextType;
+  if (!ctx) throw new Error('useCart must be used within a CartProvider');
+  return ctx;
+}
+
+export function CartProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(
+    cartReducer,
+    initialState,
+    () => {
+      try {
+        const stored = safeStorage.getItem('cart');
+        return stored ? { items: JSON.parse(stored) as CartItem[] } : initialState;
+      } catch {
+        return initialState;
+      }
+    }
+  );
+
+  useEffect(() => {
+    safeStorage.setItem('cart', JSON.stringify(state.items));
+  }, [state.items]);
+
+  const value: CartContextType = {
+    items: state.items,
+    dispatch,
+  };
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+}

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -7,3 +7,4 @@ export {
   useRequestQuoteWizard
 } from './RequestQuoteWizard';
 export { ViewModeProvider, useViewMode } from './ViewModeContext';
+export { CartProvider, useCart } from './CartContext';

--- a/src/layout/MainNavigation.tsx
+++ b/src/layout/MainNavigation.tsx
@@ -2,7 +2,8 @@
 import { Link, useLocation } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/useAuth";
-import { MessageSquare } from "lucide-react";
+import { MessageSquare, ShoppingCart } from "lucide-react";
+import { useCart } from "@/context/CartContext";
 import { useTranslation } from "react-i18next";
 
 interface MainNavigationProps {
@@ -16,6 +17,8 @@ export function MainNavigation({ isAdmin = false, unreadCount = 0, className }: 
   const isAuthenticated = !!user;
   const location = useLocation();
   const { t } = useTranslation();
+  const { items } = useCart();
+  const cartCount = items.reduce((sum, i) => sum + i.quantity, 0);
 
   const baseLinks = [
     {
@@ -113,6 +116,27 @@ export function MainNavigation({ isAdmin = false, unreadCount = 0, className }: 
             </Link>
           </li>
         )}
+
+        {/* Cart icon with badge */}
+        <li>
+          <Link
+            to="/cart"
+            className={cn(
+              "inline-flex h-9 items-center justify-center rounded-md px-4 text-sm font-medium transition-colors relative",
+              location.pathname.startsWith('/cart')
+                ? 'bg-zion-purple/20 text-zion-cyan'
+                : 'text-white hover:bg-zion-purple/10 hover:text-zion-cyan'
+            )}
+          >
+            <ShoppingCart className="w-4 h-4 mr-1" />
+            Cart
+            {cartCount > 0 && (
+              <span className="absolute -top-1 -right-1 bg-zion-purple text-white text-xs rounded-full h-5 w-5 flex items-center justify-center">
+                {cartCount}
+              </span>
+            )}
+          </Link>
+        </li>
       </ul>
     </nav>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,6 +22,7 @@ import { NotificationProvider } from './context';
 // Import analytics provider
 import { AnalyticsProvider } from './context/AnalyticsContext';
 import { ViewModeProvider } from './context/ViewModeContext';
+import { CartProvider } from './context/CartContext';
 import { registerServiceWorker } from './serviceWorkerRegistration';
 
 // Initialize a React Query client with global error handling
@@ -49,9 +50,11 @@ try {
                   <AnalyticsProvider>
                     <LanguageProvider authState={{ isAuthenticated: false, user: null }}>
                       <ViewModeProvider>
-                        <AppLayout>
-                          <App />
-                        </AppLayout>
+                        <CartProvider>
+                          <AppLayout>
+                            <App />
+                          </AppLayout>
+                        </CartProvider>
                       </ViewModeProvider>
                       <LanguageDetectionPopup />
                     </LanguageProvider>

--- a/src/pages/NewProductsPage.tsx
+++ b/src/pages/NewProductsPage.tsx
@@ -15,6 +15,7 @@ export default function NewProductsPage() {
       title="New Products"
       description="Explore our latest products priced for today's market."
       categorySlug="new-products"
+      detailBasePath="/product"
       listings={listings}
       categoryFilters={CATEGORY_FILTERS}
       initialPrice={{ min: 0, max: 5000 }}

--- a/src/pages/ProductPage.tsx
+++ b/src/pages/ProductPage.tsx
@@ -1,0 +1,37 @@
+import { useParams } from 'react-router-dom';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { NEW_PRODUCTS } from '@/data/newProductsData';
+import { useCart } from '@/context/CartContext';
+import { toast } from '@/hooks/use-toast';
+
+export default function ProductPage() {
+  const { id } = useParams();
+  const product = NEW_PRODUCTS.find(p => p.id === id);
+  const { dispatch } = useCart();
+  const [adding, setAdding] = useState(false);
+
+  if (!product) {
+    return <div className="p-6 text-white">Product not found</div>;
+  }
+
+  const handleAdd = () => {
+    setAdding(true);
+    dispatch({
+      type: 'ADD_ITEM',
+      payload: { id: product.id, name: product.title, price: product.price ?? 0, quantity: 1 }
+    });
+    toast({ title: 'Added to cart', variant: 'success' });
+    setTimeout(() => setAdding(false), 500);
+  };
+
+  return (
+    <div className="min-h-screen bg-zion-blue p-6 text-white">
+      <h1 className="text-2xl font-bold mb-4">{product.title}</h1>
+      <p className="mb-6">{product.description}</p>
+      <Button onClick={handleAdd} disabled={adding}>
+        {adding ? 'Adding...' : 'Add to Cart'}
+      </Button>
+    </div>
+  );
+}

--- a/src/types/cart.ts
+++ b/src/types/cart.ts
@@ -1,0 +1,16 @@
+export interface CartItem {
+  id: string;
+  name: string;
+  price: number;
+  quantity: number;
+}
+
+export interface CartContextType {
+  items: CartItem[];
+  dispatch: React.Dispatch<CartAction>;
+}
+
+export type CartAction =
+  | { type: 'ADD_ITEM'; payload: CartItem }
+  | { type: 'REMOVE_ITEM'; payload: string }
+  | { type: 'CLEAR_CART' };


### PR DESCRIPTION
## Summary
- create cart context and provider storing items in localStorage
- show cart badge in desktop and mobile navbars
- add product page with cart dispatch and toast
- link new-products listings to the product page
- wrap the app in `CartProvider`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find type definition file for 'react')*
- `npm run test` *(fails: vitest not found)*