### PR TITLE
Add CI workflow and deployment docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Set up Python
+        if: hashFiles('requirements.txt') != ''
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Cache pip dependencies
+        if: hashFiles('requirements.txt') != ''
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - run: npm ci
+      - name: Install Python dependencies
+        if: hashFiles('requirements.txt') != ''
+        run: pip install -r requirements.txt
+
+      - run: npm run lint
+      - run: npm run test
+      - run: npm run build
+
+      - name: Trigger Netlify build
+        if: success()
+        run: |
+          curl -X POST -d '{}' "$NETLIFY_BUILD_HOOK_URL"
+        env:
+          NETLIFY_BUILD_HOOK_URL: ${{ secrets.NETLIFY_BUILD_HOOK_URL }}
+
+      - name: Notify Slack on failure
+        if: failure()
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data '{"text":"CI failed for ${{ github.repository }}"}' \
+            "$SLACK_WEBHOOK_URL"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,15 @@
+# Deployment Pipeline
+
+This project uses GitHub Actions to run tests, lint the codebase and build the application. After a successful build a Netlify deploy hook is called to publish the site.
+
+## Workflow overview
+
+1. Install Node and (optionally) Python dependencies
+2. Cache `node_modules` and pip downloads to speed up subsequent runs
+3. Run `npm run lint`, `npm run test` and `npm run build`
+4. If all steps succeed, trigger Netlify using the build hook URL
+5. If the workflow fails, a Slack message is sent
+
+Environment variables `NETLIFY_BUILD_HOOK_URL` and `SLACK_WEBHOOK_URL` must be configured in the repository secrets for the hook and Slack notification to work.
+
+The workflow definition lives in `.github/workflows/ci.yml`.


### PR DESCRIPTION
## Summary
- add workflow to run lint, tests and build
- trigger Netlify deploy hook on success
- cache Node and Python dependencies
- notify Slack on failure
- document deployment process

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type definitions)*