### PR TITLE
Add push notifications and API endpoints

### DIFF
--- a/backend/notifications/__init__.py
+++ b/backend/notifications/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'backend.notifications.apps.NotificationsConfig'

--- a/backend/notifications/apps.py
+++ b/backend/notifications/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+class NotificationsConfig(AppConfig):
+    name = 'backend.notifications'
+
+    def ready(self):
+        from . import signals  # noqa

--- a/backend/notifications/models.py
+++ b/backend/notifications/models.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+from django.db import models
+
+class Notification(models.Model):
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    title = models.CharField(max_length=255)
+    message = models.TextField()
+    read = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['-created_at']

--- a/backend/notifications/signals.py
+++ b/backend/notifications/signals.py
@@ -1,0 +1,69 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from sendgrid import SendGridAPIClient
+from sendgrid.helpers.mail import Mail
+from django.conf import settings
+
+from .models import Notification
+from orders.models import Order
+from messaging.models import Message
+from quotes.models import QuoteReply
+
+
+def send_email(to_email: str, subject: str, html: str):
+    sg = SendGridAPIClient(settings.SENDGRID_API_KEY)
+    msg = Mail(
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        to_emails=to_email,
+        subject=subject,
+        html_content=html,
+    )
+    sg.send(msg)
+
+
+@receiver(post_save, sender=Order)
+def order_created_email(sender, instance: Order, created: bool, **kwargs):
+    if not created:
+        return
+    Notification.objects.create(
+        user=instance.user,
+        title="Order Created",
+        message=f"Your order #{instance.id} was received."
+    )
+    send_email(
+        instance.user.email,
+        "Order Created",
+        f"Your order #{instance.id} has been placed."
+    )
+
+
+@receiver(post_save, sender=Message)
+def message_received_email(sender, instance: Message, created: bool, **kwargs):
+    if not created:
+        return
+    Notification.objects.create(
+        user=instance.recipient,
+        title="New Message",
+        message=instance.content
+    )
+    send_email(
+        instance.recipient.email,
+        "New Message",
+        instance.content
+    )
+
+
+@receiver(post_save, sender=QuoteReply)
+def quote_reply_email(sender, instance: QuoteReply, created: bool, **kwargs):
+    if not created:
+        return
+    Notification.objects.create(
+        user=instance.quote.user,
+        title="Quote Reply",
+        message=instance.content
+    )
+    send_email(
+        instance.quote.user.email,
+        "Quote Reply",
+        instance.content
+    )

--- a/pages/api/notifications/[id].ts
+++ b/pages/api/notifications/[id].ts
@@ -1,0 +1,64 @@
+import { createClient } from '@supabase/supabase-js';
+
+interface Req {
+  method?: string;
+  query?: { id?: string };
+  body?: any;
+}
+interface JsonRes {
+  status: (code: number) => JsonRes;
+  json: (data: any) => void;
+  end: (data?: any) => void;
+  setHeader: (name: string, value: string) => void;
+}
+
+const supabaseUrl =
+  process.env.SUPABASE_URL ||
+  process.env.VITE_SUPABASE_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  '';
+const serviceKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  '';
+const supabase = createClient(supabaseUrl, serviceKey);
+
+export default async function handler(req: Req, res: JsonRes) {
+  const id = req.query?.id;
+  if (!id) {
+    res.status(400).json({ error: 'Missing id' });
+    return;
+  }
+
+  if (req.method === 'PATCH') {
+    const { read } = req.body || {};
+    const { error } = await supabase
+      .from('notifications')
+      .update({ read: read !== false })
+      .eq('id', id);
+
+    if (error) {
+      res.status(500).json({ error: error.message });
+      return;
+    }
+    res.status(200).json({ success: true });
+    return;
+  }
+
+  if (req.method === 'DELETE') {
+    const { error } = await supabase
+      .from('notifications')
+      .delete()
+      .eq('id', id);
+
+    if (error) {
+      res.status(500).json({ error: error.message });
+      return;
+    }
+    res.status(200).json({ success: true });
+    return;
+  }
+
+  res.status(405).end();
+}

--- a/pages/api/notifications/index.ts
+++ b/pages/api/notifications/index.ts
@@ -1,0 +1,52 @@
+import { createClient } from '@supabase/supabase-js';
+
+// Generic request/response types
+interface Req {
+  method?: string;
+  query?: { userId?: string };
+  body?: any;
+}
+interface JsonRes {
+  status: (code: number) => JsonRes;
+  json: (data: any) => void;
+  end: (data?: any) => void;
+  setHeader: (name: string, value: string) => void;
+}
+
+const supabaseUrl =
+  process.env.SUPABASE_URL ||
+  process.env.VITE_SUPABASE_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  '';
+const serviceKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  '';
+const supabase = createClient(supabaseUrl, serviceKey);
+
+export default async function handler(req: Req, res: JsonRes) {
+  if (req.method !== 'GET') {
+    res.status(405).end();
+    return;
+  }
+
+  const userId = req.query?.userId;
+  if (!userId) {
+    res.status(400).json({ error: 'Missing userId' });
+    return;
+  }
+
+  const { data, error } = await supabase
+    .from('notifications')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    res.status(500).json({ error: error.message });
+    return;
+  }
+
+  res.status(200).json(data || []);
+}

--- a/pages/api/push/subscribe.ts
+++ b/pages/api/push/subscribe.ts
@@ -1,0 +1,19 @@
+interface Req {
+  method?: string;
+  body?: any;
+}
+interface JsonRes {
+  status: (code: number) => JsonRes;
+  json: (data: any) => void;
+  end: (data?: any) => void;
+}
+
+export default async function handler(req: Req, res: JsonRes) {
+  if (req.method !== 'POST') {
+    res.status(405).end();
+    return;
+  }
+
+  console.log('Push subscription received', req.body);
+  res.status(200).json({ success: true });
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -57,3 +57,14 @@ self.addEventListener('fetch', event => {
     })
   );
 });
+
+// Display notifications from push events
+self.addEventListener('push', event => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || 'Zion Notification';
+  const options = {
+    body: data.body,
+    icon: '/vite.svg'
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -1,0 +1,5 @@
+import { NotificationCenter } from './NotificationCenter';
+
+export function NotificationBell() {
+  return <NotificationCenter />;
+}

--- a/src/context/notifications/useNotificationOperations.ts
+++ b/src/context/notifications/useNotificationOperations.ts
@@ -1,6 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
 import { safeStorage } from '@/utils/safeStorage';
-import { supabase } from '@/integrations/supabase/client';
 import { Notification, FilterType, NotificationContextType } from './types';
 
 export const useNotificationOperations = (userId?: string): NotificationContextType => {
@@ -19,13 +18,9 @@ export const useNotificationOperations = (userId?: string): NotificationContextT
 
     setLoading(true);
     try {
-      const { data, error } = await supabase
-        .from('notifications')
-        .select('*')
-        .eq('user_id', userId)
-        .order('created_at', { ascending: false });
-
-      if (error) throw error;
+      const res = await fetch(`/api/notifications?userId=${userId}`);
+      if (!res.ok) throw new Error('Failed');
+      const data = await res.json();
       setNotifications(data || []);
     } catch (err) {
       console.error('Error fetching notifications:', err);
@@ -38,13 +33,11 @@ export const useNotificationOperations = (userId?: string): NotificationContextT
     if (!userId) return;
 
     try {
-      const { error } = await supabase
-        .from('notifications')
-        .update({ read: true })
-        .eq('id', id)
-        .eq('user_id', userId);
-
-      if (error) throw error;
+      await fetch(`/api/notifications/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ read: true })
+      });
       await fetchNotifications();
     } catch (err) {
       console.error('Error marking notification as read:', err);
@@ -55,30 +48,28 @@ export const useNotificationOperations = (userId?: string): NotificationContextT
     if (!userId) return;
 
     try {
-      const { error } = await supabase
-        .from('notifications')
-        .update({ read: true })
-        .eq('user_id', userId)
-        .eq('read', false);
-
-      if (error) throw error;
+      await Promise.all(
+        notifications
+          .filter(n => !n.read)
+          .map(n =>
+            fetch(`/api/notifications/${n.id}`, {
+              method: 'PATCH',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ read: true })
+            })
+          )
+      );
       await fetchNotifications();
     } catch (err) {
       console.error('Error marking all notifications as read:', err);
     }
-  }, [userId, fetchNotifications]);
+  }, [userId, fetchNotifications, notifications]);
 
   const dismissNotification = useCallback(async (id: string) => {
     if (!userId) return;
 
     try {
-      const { error } = await supabase
-        .from('notifications')
-        .delete()
-        .eq('id', id)
-        .eq('user_id', userId);
-
-      if (error) throw error;
+      await fetch(`/api/notifications/${id}`, { method: 'DELETE' });
       await fetchNotifications();
     } catch (err) {
       console.error('Error dismissing notification:', err);

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState, useEffect, ReactNode } from
 import { supabase } from "@/integrations/supabase/client";
 import { AuthContext } from "@/context/auth/AuthContext";
 import type { UserDetails as AuthUserDetails } from "@/types/auth";
+import { subscribeToPush } from "@/utils/pushSubscription";
 
 // Define types for our context
 export interface UserDetails {
@@ -50,7 +51,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // This would be replaced with actual Supabase auth
     console.log("Sign in attempted with:", email);
     // Mock successful sign-in
-    setUser({ 
+    setUser({
       id: "mock-user-id", 
       email, 
       displayName: "Mock User", 
@@ -61,6 +62,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       permissions: ["billing_access", "admin_access", "team_management"],
       companyId: "company-123"
     });
+    // Subscribe user to push notifications after login
+    try {
+      await subscribeToPush();
+    } catch (err) {
+      console.error('Push subscription error', err);
+    }
     return { error: null };
   };
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,7 +6,7 @@ import { CommunityDiscussion } from "@/components/CommunityDiscussion";
 import { Badge } from "@/components/ui/badge";
 import { UserCheck, Bell, MessageSquare, LogOut, Send, Settings } from "lucide-react";
 import { createTestNotification, createOnboardingNotification, createSystemNotification } from "@/utils/notifications";
-import { NotificationCenter } from "@/components/NotificationCenter";
+import { NotificationBell } from "@/components/NotificationBell";
 import { useToast } from "@/hooks/use-toast";
 import { Link } from "react-router-dom";
 
@@ -169,7 +169,7 @@ export default function Dashboard() {
                 <div className="flex items-center justify-between mb-6">
                   <h2 className="text-2xl font-bold text-white">Dashboard</h2>
                   <div className="flex items-center gap-2">
-                    <NotificationCenter />
+                    <NotificationBell />
                     <Button 
                       variant="outline" 
                       className="text-zion-slate-light border-zion-blue-light hover:bg-zion-blue hover:text-white"

--- a/src/utils/pushSubscription.ts
+++ b/src/utils/pushSubscription.ts
@@ -1,0 +1,37 @@
+const VAPID_PUBLIC_KEY = import.meta.env.VITE_VAPID_PUBLIC_KEY;
+
+function urlBase64ToUint8Array(base64String: string) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = window.atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+export async function subscribeToPush() {
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+    return;
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    const existing = await registration.pushManager.getSubscription();
+    if (existing) return;
+
+    const subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY)
+    });
+
+    await fetch('/api/push/subscribe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(subscription)
+    });
+  } catch (err) {
+    console.error('Push subscription failed', err);
+  }
+}


### PR DESCRIPTION
## Summary
- add notification API routes
- update NotificationCenter logic to use new API
- create NotificationBell wrapper component
- subscribe to Web Push after login
- support push events in service worker
- scaffold Django app for notifications with SendGrid email signals

## Testing
- `npm run test` *(fails: vitest not found)*