### PR TITLE
Add profile management page

### DIFF
--- a/__tests__/api/user-me.test.ts
+++ b/__tests__/api/user-me.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from 'vitest';
+import handler from '@/pages/api/users/me';
+
+function mockReq(method: string, body?: any) {
+  return { method, body } as any;
+}
+function mockRes() {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  res.setHeader = vi.fn();
+  res.end = vi.fn();
+  return res;
+}
+
+test('GET returns profile', () => {
+  const req = mockReq('GET');
+  const res = mockRes();
+  handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ email: 'jane@example.com' }));
+});
+
+test('PUT updates profile', () => {
+  const req = mockReq('PUT', { name: 'New' });
+  const res = mockRes();
+  handler(req, res);
+  expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ name: 'New' }));
+});
+
+test('DELETE soft deletes account', () => {
+  const req = mockReq('DELETE');
+  const res = mockRes();
+  handler(req, res);
+  expect(res.json).toHaveBeenCalledWith({ success: true });
+});

--- a/__tests__/profile-page.test.tsx
+++ b/__tests__/profile-page.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Profile from '@/pages/Profile';
+import { vi, expect, test } from 'vitest';
+
+function mockFetch(response: any) {
+  global.fetch = vi.fn().mockResolvedValue({
+    json: () => Promise.resolve(response),
+  }) as any;
+}
+
+test('fetches profile on mount', async () => {
+  mockFetch({ id: '1', name: 'Jane', email: 'jane@example.com', avatarUrl: '', notifications: { email: true, push: false } });
+  render(<Profile />);
+  await screen.findByDisplayValue('Jane');
+  expect(global.fetch).toHaveBeenCalledWith('/api/users/me');
+});
+
+test('saves updated profile', async () => {
+  mockFetch({ id: '1', name: 'Jane', email: 'jane@example.com', avatarUrl: '', notifications: { email: true, push: false } });
+  render(<Profile />);
+  await screen.findByDisplayValue('Jane');
+  (global.fetch as any).mockResolvedValueOnce({ json: () => Promise.resolve({ id:'1', name:'New', email:'jane@example.com', avatarUrl:'', notifications:{email:true,push:false} }) });
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'New' } });
+  fireEvent.click(screen.getByText('Save'));
+  await waitFor(() => expect(global.fetch).toHaveBeenLastCalledWith('/api/users/me', expect.anything()));
+});

--- a/pages/api/users/me.ts
+++ b/pages/api/users/me.ts
@@ -1,0 +1,45 @@
+let mockUser = {
+  id: '1',
+  name: 'Jane Doe',
+  email: 'jane@example.com',
+  avatarUrl: '',
+  notifications: {
+    email: true,
+    push: false,
+  },
+  softDeleted: false,
+};
+
+// Generic request/response types so this file works in Node or Next.js
+interface Req {
+  method?: string;
+  body?: any;
+}
+interface JsonRes {
+  statusCode?: number;
+  setHeader: (name: string, value: string) => void;
+  end: (data?: any) => void;
+  status: (code: number) => JsonRes;
+  json: (data: any) => void;
+}
+
+export default function handler(req: Req, res: JsonRes) {
+  if (req.method === 'GET') {
+    res.status(200).json(mockUser);
+    return;
+  }
+
+  if (req.method === 'PUT') {
+    mockUser = { ...mockUser, ...req.body };
+    res.status(200).json(mockUser);
+    return;
+  }
+
+  if (req.method === 'DELETE') {
+    mockUser.softDeleted = true;
+    res.status(200).json({ success: true });
+    return;
+  }
+
+  res.status(405).end();
+}

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,0 +1,1 @@
+export { default } from '../src/pages/Profile';

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,88 +1,157 @@
+import { useEffect, useState } from 'react';
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from '@/components/ui/tabs';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+} from '@/components/ui/avatar';
 
-import React, { useEffect } from 'react';
-import { Header } from "@/components/Header";
-import { Footer } from "@/components/Footer";
-import { useAuth } from "@/hooks/useAuth";
-import { Button } from "@/components/ui/button";
-import { useNavigate } from "react-router-dom";
-import { toast } from "sonner";
+interface User {
+  id: string;
+  name: string;
+  email: string;
+  avatarUrl: string;
+  notifications: { email: boolean; push: boolean };
+  softDeleted?: boolean;
+}
 
 export default function Profile() {
-  const { user, isLoading, logout } = useAuth();
-  const navigate = useNavigate();
+  const [user, setUser] = useState<User | null>(null);
+  const [avatarPreview, setAvatarPreview] = useState<string>('');
 
   useEffect(() => {
-    if (!isLoading && !user) {
-      toast.error("Please log in to view your profile");
-      navigate("/login?redirect=/profile");
-    }
-  }, [user, isLoading, navigate]);
+    fetch('/api/users/me')
+      .then(res => res.json())
+      .then(setUser)
+      .catch(() => {});
+  }, []);
 
-  if (isLoading) {
-    return (
-      <>
-        <Header />
-        <div className="min-h-screen bg-zion-blue flex items-center justify-center">
-          <div className="animate-pulse text-white">Loading profile...</div>
-        </div>
-        <Footer />
-      </>
-    );
-  }
+  const handleSave = async () => {
+    if (!user) return;
+    const res = await fetch('/api/users/me', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(user),
+    });
+    const data = await res.json();
+    setUser(data);
+  };
+
+  const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setAvatarPreview(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleDelete = async () => {
+    const confirm = window.prompt('Enter password to confirm');
+    if (!confirm) return;
+    await fetch('/api/users/me', { method: 'DELETE' });
+    setUser(prev => (prev ? { ...prev, softDeleted: true } : prev));
+  };
 
   if (!user) {
     return (
-      <>
-        <Header />
-        <div className="min-h-screen bg-zion-blue flex items-center justify-center">
-          <div className="bg-zion-blue-dark border border-zion-blue-light rounded-lg p-6 max-w-md">
-            <h1 className="text-xl font-bold text-white mb-4">Please log in</h1>
-            <p className="text-zion-slate mb-4">You need to be logged in to view your profile.</p>
-            <Button 
-              onClick={() => navigate("/login?redirect=/profile")}
-              className="bg-gradient-to-r from-zion-purple to-zion-purple-dark hover:from-zion-purple-light hover:to-zion-purple text-white"
-            >
-              Go to Login
-            </Button>
-          </div>
-        </div>
-        <Footer />
-      </>
+      <div className="p-4">Loading...</div>
     );
   }
 
   return (
-    <>
-      <Header />
-      <div className="min-h-screen bg-zion-blue">
-        <div className="container mx-auto px-4 py-8">
-          <h1 className="text-2xl font-bold text-white mb-8">My Profile</h1>
-          <div className="bg-zion-blue-dark border border-zion-blue-light rounded-lg p-6">
-            <div className="flex flex-col md:flex-row gap-6">
-              <div className="md:w-1/3">
-                <div className="w-32 h-32 rounded-full bg-zion-purple flex items-center justify-center text-3xl font-bold text-white mb-4 mx-auto md:mx-0">
-                  {user.displayName ? user.displayName.split(' ').map(name => name[0]).join('') : user.email?.charAt(0)}
-                </div>
-              </div>
-              <div className="md:w-2/3">
-                <h2 className="text-xl font-bold text-white">{user.displayName || "User"}</h2>
-                <p className="text-zion-slate-light mb-4">{user.email}</p>
-                <Button
-                  onClick={() => {
-                    logout();
-                    navigate("/");
-                  }}
-                  variant="outline"
-                  className="border-zion-blue-light text-zion-slate-light hover:bg-zion-blue-light hover:text-white"
-                >
-                  Logout
-                </Button>
-              </div>
+    <div className="container mx-auto p-4">
+      <Tabs defaultValue="info" className="w-full">
+        <TabsList className="grid w-full max-w-md mx-auto grid-cols-3 mb-4">
+          <TabsTrigger value="info">Personal Info</TabsTrigger>
+          <TabsTrigger value="security">Security</TabsTrigger>
+          <TabsTrigger value="notifications">Notifications</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="info">
+          <div className="space-y-4">
+            <div>
+              <Avatar className="w-24 h-24 mb-2">
+                {avatarPreview || user.avatarUrl ? (
+                  <AvatarImage src={avatarPreview || user.avatarUrl} alt="avatar" />
+                ) : (
+                  <AvatarFallback>{user.name?.charAt(0)}</AvatarFallback>
+                )}
+              </Avatar>
+              <Input type="file" aria-label="avatar" onChange={handleAvatarChange} />
+            </div>
+            <div>
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                value={user.name}
+                onChange={e => setUser({ ...user, name: e.target.value })}
+              />
+            </div>
+            <div>
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                value={user.email}
+                onChange={e => setUser({ ...user, email: e.target.value })}
+              />
+            </div>
+            <Button onClick={handleSave}>Save</Button>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="security">
+          <Button variant="destructive" onClick={handleDelete}>
+            Delete account
+          </Button>
+        </TabsContent>
+
+        <TabsContent value="notifications">
+          <div className="space-y-2">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="nemail"
+                checked={user.notifications.email}
+                onCheckedChange={v =>
+                  setUser({
+                    ...user,
+                    notifications: { ...user.notifications, email: !!v },
+                  })
+                }
+              />
+              <label htmlFor="nemail" className="text-sm text-white">
+                Email notifications
+              </label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="npush"
+                checked={user.notifications.push}
+                onCheckedChange={v =>
+                  setUser({
+                    ...user,
+                    notifications: { ...user.notifications, push: !!v },
+                  })
+                }
+              />
+              <label htmlFor="npush" className="text-sm text-white">
+                Push notifications
+              </label>
             </div>
           </div>
-        </div>
-      </div>
-      <Footer />
-    </>
+        </TabsContent>
+      </Tabs>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `/api/users/me` endpoint with GET/PUT/DELETE for profile data
- replace `src/pages/Profile.tsx` with a tabbed profile management page
- expose the new page via `/profile` route
- add unit tests for the API and page

## Testing
- `npm run test` *(fails: vitest not found)*