### PR TITLE
Implement wishlist favorites

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,22 @@
+from django.db import models
+from django.contrib.auth import get_user_model
+
+class Favorite(models.Model):
+    """Item a user has saved for later."""
+
+    ITEM_TYPE_CHOICES = [
+        ("product", "Product"),
+        ("service", "Service"),
+        ("talent", "Talent"),
+    ]
+
+    user = models.ForeignKey(get_user_model(), on_delete=models.CASCADE)
+    item_type = models.CharField(max_length=20, choices=ITEM_TYPE_CHOICES)
+    item_id = models.CharField(max_length=255)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ("user", "item_type", "item_id")
+
+    def __str__(self) -> str:
+        return f"{self.user_id} -> {self.item_type}:{self.item_id}"

--- a/pages/api/favorites.ts
+++ b/pages/api/favorites.ts
@@ -1,0 +1,88 @@
+import { createClient } from '@supabase/supabase-js';
+
+// Basic req/res types
+type Req = { method?: string; body?: any; query?: any };
+interface JsonRes {
+  statusCode?: number;
+  setHeader: (name: string, value: string) => void;
+  end: (data?: any) => void;
+  status: (code: number) => JsonRes;
+  json: (data: any) => void;
+}
+
+const supabaseUrl =
+  process.env.SUPABASE_URL ||
+  process.env.VITE_SUPABASE_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  '';
+const serviceKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  '';
+
+const supabase = createClient(supabaseUrl, serviceKey);
+
+export default async function handler(req: Req, res: JsonRes) {
+  const userId = req.body?.user_id || req.query?.userId;
+
+  if (!userId) {
+    res.status(400).json({ error: 'Missing userId' });
+    return;
+  }
+
+  if (req.method === 'GET') {
+    const { data, error } = await supabase
+      .from('favorites')
+      .select('item_type, item_id, created_at')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      res.status(500).json({ error: error.message });
+      return;
+    }
+
+    res.status(200).json(data || []);
+    return;
+  }
+
+  const { item_type, item_id } = req.body || {};
+  if (!item_type || !item_id) {
+    res.status(400).json({ error: 'Missing item_type or item_id' });
+    return;
+  }
+
+  if (req.method === 'POST') {
+    const { error } = await supabase
+      .from('favorites')
+      .insert({ user_id: userId, item_type, item_id });
+
+    if (error) {
+      res.status(500).json({ error: error.message });
+      return;
+    }
+
+    res.status(200).json({ success: true });
+    return;
+  }
+
+  if (req.method === 'DELETE') {
+    const { error } = await supabase
+      .from('favorites')
+      .delete()
+      .eq('user_id', userId)
+      .eq('item_type', item_type)
+      .eq('item_id', item_id);
+
+    if (error) {
+      res.status(500).json({ error: error.message });
+      return;
+    }
+
+    res.status(200).json({ success: true });
+    return;
+  }
+
+  res.status(405).end();
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ import ZionHireAI from './pages/ZionHireAI';
 import RequestQuotePage from './pages/RequestQuote';
 import CartPage from './pages/Cart';
 import CheckoutPage from './pages/Checkout';
+import WishlistPage from './pages/Wishlist';
 
 const baseRoutes = [
   { path: '/', element: <Home /> },
@@ -79,6 +80,7 @@ const baseRoutes = [
   { path: '/request-quote', element: <RequestQuotePage /> },
   { path: '/blog', element: <Blog /> },
   { path: '/blog/:slug', element: <BlogPost /> },
+  { path: '/wishlist', element: <WishlistPage /> },
   { path: '/cart', element: <CartPage /> },
   { path: '/checkout', element: <CheckoutPage /> },
 ];

--- a/src/components/FavoriteButton.tsx
+++ b/src/components/FavoriteButton.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Heart } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useFavorites } from '@/hooks/useFavorites';
+import { useAuth } from '@/hooks/useAuth';
+import { useToast } from '@/hooks/use-toast';
+
+interface FavoriteButtonProps {
+  itemId: string;
+  itemType: string;
+  className?: string;
+}
+
+export function FavoriteButton({ itemId, itemType, className }: FavoriteButtonProps) {
+  const { isFavorite, toggleFavorite } = useFavorites();
+  const { user } = useAuth();
+  const { toast } = useToast();
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!user) {
+      toast({
+        title: 'Authentication required',
+        description: 'Please log in to save items to your favorites',
+        variant: 'destructive'
+      });
+      return;
+    }
+    toggleFavorite(itemType, itemId);
+  };
+
+  const active = isFavorite(itemType, itemId);
+
+  return (
+    <button
+      className={cn(
+        'absolute top-2 right-2 z-10 p-2 rounded-full bg-zion-blue-dark/80 hover:bg-zion-blue-light/30 transition-colors',
+        className
+      )}
+      onClick={handleClick}
+      aria-label={active ? 'Remove from favorites' : 'Save to favorites'}
+    >
+      <Heart className={cn('h-4 w-4', active ? 'fill-red-500 text-red-500' : 'text-zion-slate')} />
+    </button>
+  );
+}

--- a/src/components/ProductListingCard.tsx
+++ b/src/components/ProductListingCard.tsx
@@ -3,6 +3,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ProductListing } from "@/types/listings";
 import { Star, DollarSign } from "lucide-react";
+import { FavoriteButton } from "@/components/FavoriteButton";
 
 interface ProductListingCardProps {
   listing: ProductListing;
@@ -78,6 +79,7 @@ export function ProductListingCard({
               Featured
             </Badge>
           )}
+          <FavoriteButton itemId={listing.id} itemType="product" />
         </div>
       </div>
       

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { useRequestQuoteWizard } from "@/context";
+import { FavoriteButton } from "@/components/FavoriteButton";
 
 interface ServiceCardProps {
   service: { id: string; title: string };
@@ -25,8 +26,9 @@ export default function ServiceCard({ service, onSelect }: ServiceCardProps) {
     <div
       data-testid={`service-card-${service.id}`}
       onClick={handleClick}
-      className="cursor-pointer p-4 border border-zion-blue-light rounded-lg bg-zion-blue-dark hover:border-zion-purple/50"
+      className="cursor-pointer p-4 border border-zion-blue-light rounded-lg bg-zion-blue-dark hover:border-zion-purple/50 relative"
     >
+      <FavoriteButton itemId={service.id} itemType="service" />
       <h3 className="text-white font-medium mb-2">{service.title}</h3>
       <Button size="sm" onClick={handleRequestQuote} data-testid="request-quote-btn">
         Request Quote

--- a/src/components/header/MobileBottomNav.tsx
+++ b/src/components/header/MobileBottomNav.tsx
@@ -1,9 +1,10 @@
 
 import React from "react";
 import { Link, useLocation } from "react-router-dom";
-import { Home, Search, BriefcaseIcon, MessageSquare, User, MessageCircle } from "lucide-react";
+import { Home, Search, BriefcaseIcon, MessageSquare, User, MessageCircle, Heart } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/useAuth";
+import { useFavorites } from "@/hooks/useFavorites";
 
 interface MobileBottomNavProps {
   unreadCount?: number;
@@ -13,6 +14,7 @@ export function MobileBottomNav({ unreadCount = 0 }: MobileBottomNavProps) {
   const location = useLocation();
   const { user } = useAuth();
   const isAuthenticated = !!user;
+  const { count: favoritesCount } = useFavorites();
 
   const navItems = [
     {
@@ -32,6 +34,14 @@ export function MobileBottomNav({ unreadCount = 0 }: MobileBottomNavProps) {
       href: "/community",
       icon: MessageCircle,
       matches: (path: string) => path.startsWith("/community") || path.startsWith("/forum")
+    },
+    {
+      name: "Wishlist",
+      href: "/wishlist",
+      icon: Heart,
+      matches: (path: string) => path.startsWith("/wishlist"),
+      badge: favoritesCount,
+      authRequired: true
     },
     {
       name: "Messages",

--- a/src/components/talent/TalentCard.tsx
+++ b/src/components/talent/TalentCard.tsx
@@ -1,17 +1,15 @@
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Star, MapPin, Clock, ArrowRight, CheckCircle2 } from "lucide-react";
-import { useNavigate, useLocation } from "react-router-dom";
-import { useToast } from "@/hooks/use-toast";
+import { MapPin, Clock, ArrowRight, CheckCircle2 } from "lucide-react";
+import { FavoriteButton } from "@/components/FavoriteButton";
+import { useNavigate } from "react-router-dom";
 import { TalentProfile } from "@/types/talent";
 
 export interface TalentCardProps {
   talent: TalentProfile;
   onViewProfile: (id: string) => void;
   onRequestHire: (talent: TalentProfile) => void;
-  isSaved: boolean;
-  onToggleSave: (id: string, isSaved: boolean) => void;
   isAuthenticated: boolean;
 }
 
@@ -19,13 +17,9 @@ export function TalentCard({
   talent,
   onViewProfile,
   onRequestHire,
-  isSaved,
-  onToggleSave,
   isAuthenticated
 }: TalentCardProps) {
   const navigate = useNavigate();
-  const location = useLocation();
-  const { toast } = useToast();
   
   const handleViewProfile = () => {
     // Navigate directly to the talent profile
@@ -45,24 +39,6 @@ export function TalentCard({
     }
   };
 
-  const handleToggleSave = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (!isAuthenticated) {
-      toast({
-        title: "Authentication required",
-        description: "Please log in to save talents to your favorites",
-        variant: "destructive"
-      });
-      const next = encodeURIComponent(location.pathname + location.search);
-      navigate(`/login?next=${next}`);
-      return;
-    }
-
-    if (onToggleSave) {
-      onToggleSave(talent.id, !isSaved);
-    }
-  };
 
   // Extract skills - limit to 5 for display
   const skills = talent.skills?.slice(0, 5) || [];
@@ -101,15 +77,7 @@ export function TalentCard({
           <div className="flex-1">
             <div className="flex justify-between items-start">
               <h3 className="text-lg font-bold text-white">{talent.full_name}</h3>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="p-1 h-auto text-zion-slate-light hover:text-zion-cyan"
-                onClick={handleToggleSave}
-              >
-                <Star className={`h-5 w-5 ${isSaved ? "fill-yellow-400 text-yellow-400" : ""}`} />
-                <span className="sr-only">{isSaved ? "Saved" : "Save"}</span>
-              </Button>
+              <FavoriteButton itemId={talent.id} itemType="talent" className="-mt-1" />
             </div>
             <p className="text-white font-medium">{talent.professional_title}</p>
             

--- a/src/components/talent/TalentGrid.tsx
+++ b/src/components/talent/TalentGrid.tsx
@@ -6,8 +6,6 @@ export interface TalentGridProps {
   talents: TalentProfile[];
   isLoading: boolean;
   onTalentClick: (id: string) => void;
-  savedTalentIds: string[];
-  onToggleSave: (id: string, isSaved: boolean) => void;
   isAuthenticated: boolean;
   viewProfile?: (id: string) => void;
   clearFilters?: () => void;
@@ -18,8 +16,6 @@ export function TalentGrid({
   talents, 
   isLoading, 
   onTalentClick, 
-  savedTalentIds, 
-  onToggleSave, 
   isAuthenticated,
   viewProfile,
   clearFilters,
@@ -71,8 +67,6 @@ export function TalentGrid({
           talent={talent}
           onViewProfile={() => handleViewProfile(talent.id)}
           onRequestHire={() => handleRequestHireInternal(talent)}
-          isSaved={savedTalentIds.includes(talent.id)}
-          onToggleSave={onToggleSave}
           isAuthenticated={isAuthenticated}
         />
       ))}

--- a/src/components/talent/TalentResults.tsx
+++ b/src/components/talent/TalentResults.tsx
@@ -11,8 +11,6 @@ interface TalentResultsProps {
   isLoading: boolean;
   viewProfile: (id: string) => void;
   handleRequestHire: (talent: TalentProfile) => void;
-  savedTalents: string[];
-  handleToggleSave: (id: string, isSaved: boolean) => void;
   isAuthenticated: boolean;
   activeFiltersProps: {
     selectedSkills: string[];
@@ -35,8 +33,6 @@ export function TalentResults({
   isLoading,
   viewProfile,
   handleRequestHire,
-  savedTalents,
-  handleToggleSave,
   isAuthenticated,
   activeFiltersProps
 }: TalentResultsProps) {
@@ -58,8 +54,6 @@ export function TalentResults({
         onTalentClick={viewProfile}
         viewProfile={viewProfile}
         handleRequestHire={handleRequestHire}
-        savedTalentIds={savedTalents}
-        onToggleSave={handleToggleSave}
         isAuthenticated={isAuthenticated}
         clearFilters={activeFiltersProps.clearFilters}
       />

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -11,3 +11,4 @@ export * from './usePostsByCategory';
 export * from './useAutocomplete';
 
 export * from "./useLocalStorage";
+export * from "./useFavorites";

--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from './useAuth';
+import { safeFetch } from '@/integrations/supabase/client';
+
+export interface Favorite {
+  item_type: string;
+  item_id: string;
+  created_at?: string;
+}
+
+export function useFavorites() {
+  const { user } = useAuth();
+  const [favorites, setFavorites] = useState<Favorite[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchFavorites = async () => {
+    if (!user) {
+      setFavorites([]);
+      setLoading(false);
+      return;
+    }
+    try {
+      const res = await safeFetch(`/api/favorites?userId=${user.id}`);
+      const data = await res.json();
+      setFavorites(data || []);
+    } catch (err) {
+      console.error('Failed to fetch favorites', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchFavorites();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id]);
+
+  const toggleFavorite = async (item_type: string, item_id: string) => {
+    if (!user) return;
+    const exists = favorites.some(
+      f => f.item_type === item_type && f.item_id === item_id
+    );
+    try {
+      if (exists) {
+        await safeFetch('/api/favorites', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ user_id: user.id, item_type, item_id })
+        });
+        setFavorites(prev =>
+          prev.filter(f => !(f.item_type === item_type && f.item_id === item_id))
+        );
+      } else {
+        await safeFetch('/api/favorites', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ user_id: user.id, item_type, item_id })
+        });
+        setFavorites(prev => [...prev, { item_type, item_id }]);
+      }
+    } catch (err) {
+      console.error('Failed to toggle favorite', err);
+    }
+  };
+
+  const isFavorite = (item_type: string, item_id: string) =>
+    favorites.some(f => f.item_type === item_type && f.item_id === item_id);
+
+  return { favorites, count: favorites.length, loading, isFavorite, toggleFavorite, refetch: fetchFavorites };
+}

--- a/src/layout/MainNavigation.tsx
+++ b/src/layout/MainNavigation.tsx
@@ -2,7 +2,8 @@
 import { Link, useLocation } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/useAuth";
-import { MessageSquare } from "lucide-react";
+import { MessageSquare, Heart } from "lucide-react";
+import { useFavorites } from "@/hooks/useFavorites";
 import { useTranslation } from "react-i18next";
 
 interface MainNavigationProps {
@@ -14,6 +15,7 @@ interface MainNavigationProps {
 export function MainNavigation({ isAdmin = false, unreadCount = 0, className }: MainNavigationProps) {
   const { user } = useAuth();
   const isAuthenticated = !!user;
+  const { count } = useFavorites();
   const location = useLocation();
   const { t } = useTranslation();
 
@@ -90,6 +92,29 @@ export function MainNavigation({ isAdmin = false, unreadCount = 0, className }: 
             </Link>
           </li>
         ))}
+
+        {/* Wishlist link */}
+        {isAuthenticated && (
+          <li>
+            <Link
+              to="/wishlist"
+              aria-label="Wishlist"
+              className={cn(
+                "relative inline-flex h-9 w-9 items-center justify-center rounded-md transition-colors",
+                location.pathname === "/wishlist"
+                  ? "bg-zion-purple/20 text-zion-cyan"
+                  : "text-white hover:bg-zion-purple/10 hover:text-zion-cyan"
+              )}
+            >
+              <Heart className="w-4 h-4" />
+              {count > 0 && (
+                <span className="absolute -top-1 -right-1 bg-zion-purple text-white text-xs rounded-full h-4 w-4 flex items-center justify-center">
+                  {count}
+                </span>
+              )}
+            </Link>
+          </li>
+        )}
         
         {/* Messages link with unread counter */}
         {isAuthenticated && (

--- a/src/pages/SavedTalentsPage.tsx
+++ b/src/pages/SavedTalentsPage.tsx
@@ -187,8 +187,6 @@ export default function SavedTalentsPage() {
                 talent={talent}
                 onViewProfile={handleViewProfile}
                 onRequestHire={handleRequestHire}
-                isSaved={true}
-                onToggleSave={handleToggleSave}
                 isAuthenticated={!!user}
               />
             ))}

--- a/src/pages/TalentDirectory.tsx
+++ b/src/pages/TalentDirectory.tsx
@@ -43,13 +43,11 @@ export default function TalentDirectory() {
     setSelectedTalent,
     expandedSections,
     isAuthenticated,
-    savedTalents,
     toggleSkill,
     toggleAvailability,
     toggleRegion,
     clearFilters,
     toggleSection,
-    handleToggleSave,
   } = useTalentDirectory();
 
   const [currentPage, setCurrentPage] = useState(1);
@@ -128,8 +126,6 @@ export default function TalentDirectory() {
               isLoading={isLoading}
               viewProfile={viewProfile}
               handleRequestHire={handleRequestHire}
-              savedTalents={savedTalents}
-              handleToggleSave={handleToggleSave}
               isAuthenticated={isAuthenticated}
               activeFiltersProps={{
                 selectedSkills,

--- a/src/pages/Wishlist.tsx
+++ b/src/pages/Wishlist.tsx
@@ -1,0 +1,73 @@
+import { useFavorites } from '@/hooks/useFavorites';
+import { MARKETPLACE_LISTINGS } from '@/data/marketplaceData';
+import { TALENT_PROFILES } from '@/data/talentData';
+import { ProductListingCard } from '@/components/ProductListingCard';
+import { TalentCard } from '@/components/talent/TalentCard';
+import { Button } from '@/components/ui/button';
+import { safeStorage } from '@/utils/safeStorage';
+import { useAuth } from '@/hooks/useAuth';
+import { useNavigate } from 'react-router-dom';
+
+export default function WishlistPage() {
+  const { favorites, loading } = useFavorites();
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  if (!user) {
+    navigate('/login');
+    return null;
+  }
+
+  const addToCart = (item: { id: string; title?: string; price?: number }) => {
+    const stored = safeStorage.getItem('cart');
+    const cart = stored ? JSON.parse(stored) : [];
+    cart.push({ id: item.id, name: item.title || 'Item', price: item.price || 0, quantity: 1 });
+    safeStorage.setItem('cart', JSON.stringify(cart));
+  };
+
+  const productMap = MARKETPLACE_LISTINGS.reduce<Record<string, any>>((acc, p) => {
+    acc[p.id] = p;
+    return acc;
+  }, {});
+  const talentMap = TALENT_PROFILES.reduce<Record<string, any>>((acc, t) => {
+    acc[t.id] = t;
+    return acc;
+  }, {});
+
+  return (
+    <div className="container py-8">
+      <h1 className="text-3xl font-bold mb-6">Wishlist</h1>
+      {loading ? (
+        <p>Loading...</p>
+      ) : favorites.length === 0 ? (
+        <p>No items saved.</p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {favorites.map(fav => {
+            if (fav.item_type === 'talent') {
+              const talent = talentMap[fav.item_id];
+              return talent ? (
+                <TalentCard
+                  key={fav.item_id}
+                  talent={talent}
+                  onViewProfile={() => {}}
+                  onRequestHire={() => {}}
+                  isAuthenticated={true}
+                />
+              ) : null;
+            }
+            const item = productMap[fav.item_id];
+            return item ? (
+              <div key={fav.item_id} className="relative">
+                <ProductListingCard listing={item} />
+                <Button size="sm" className="absolute bottom-2 right-2" onClick={() => addToCart(item)}>
+                  Add to Cart
+                </Button>
+              </div>
+            ) : null;
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -44,8 +44,8 @@ declare module '@/components/ChatAssistant/ChatMessage' {
 declare module '@/components/ProductListingCard' {
 export interface ProductListingCardProps {
     listing: any;
-    view: any;
-    onRequestQuote: (listingId: string) => void;
+    view?: any;
+    onRequestQuote?: (listingId: string) => void;
     key?: string | number;
     detailBasePath?: string;
   }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -108,7 +108,7 @@ declare module '@/components/ProductListingCard' {
   export interface ProductListingCardProps {
     listing: any;
     view?: any;  // Made optional to fix the errors
-    onRequestQuote: (listingId: string) => void;
+    onRequestQuote?: (listingId: string) => void;
     key?: string | number;
     detailBasePath?: string;
   }

--- a/supabase/migrations/20250621_create_favorites_table.sql
+++ b/supabase/migrations/20250621_create_favorites_table.sql
@@ -1,0 +1,25 @@
+-- Create a table to store user favorites
+CREATE TABLE IF NOT EXISTS public.favorites (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  item_type TEXT NOT NULL,
+  item_id TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Prevent duplicate favorites for the same item
+CREATE UNIQUE INDEX IF NOT EXISTS favorites_user_item_idx
+  ON public.favorites (user_id, item_type, item_id);
+
+-- Enable row level security
+ALTER TABLE public.favorites ENABLE ROW LEVEL SECURITY;
+
+-- Policies
+CREATE POLICY "Users can view their favorites" ON public.favorites
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert favorites" ON public.favorites
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete favorites" ON public.favorites
+  FOR DELETE USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- create `Favorite` Django model
- add Supabase migration & API route `/api/favorites`
- implement React `useFavorites` hook
- add `<FavoriteButton>` component
- integrate heart button into product, service and talent cards
- create `/wishlist` page to manage saved items
- display wishlist count in navigation (desktop & mobile)
- fix typings for optional quote handler and remove legacy save props

## Testing
- `npm run build` *(fails: missing type definitions)*
- `npm run test` *(fails: vitest not found)*