### PR TITLE
Add coverage tests and e2e checkout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: ["**"]
   pull_request:
-    branches: [ main ]
+    branches: ["**"]
 
 jobs:
   test:

--- a/cypress/e2e/purchase-flow.cy.ts
+++ b/cypress/e2e/purchase-flow.cy.ts
@@ -1,0 +1,22 @@
+describe('purchase flow', () => {
+  it('completes checkout with Stripe test mode', () => {
+    cy.intercept('POST', '/api/checkout_sessions', {
+      statusCode: 200,
+      body: { sessionId: 'sess_test' },
+    }).as('createSession');
+
+    cy.visit('/checkout', {
+      onBeforeLoad(win) {
+        win.Stripe = function () {
+          return {
+            redirectToCheckout: cy.stub().as('redirect'),
+          } as any;
+        };
+      },
+    });
+
+    cy.contains('Buy Now').click();
+    cy.wait('@createSession');
+    cy.get('@redirect').should('have.been.called');
+  });
+});

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -1,0 +1,50 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+export interface CartItem {
+  id: string;
+  quantity: number;
+}
+
+export interface CartContextType {
+  items: CartItem[];
+  addItem: (item: CartItem) => void;
+  removeItem: (id: string) => void;
+  clear: () => void;
+}
+
+const CartContext = createContext<CartContextType>({
+  items: [],
+  addItem: () => {},
+  removeItem: () => {},
+  clear: () => {},
+});
+
+export function useCart(): CartContextType {
+  return useContext(CartContext);
+}
+
+export function CartProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<CartItem[]>([]);
+
+  const addItem = (item: CartItem) => {
+    setItems(prev => {
+      const existing = prev.find(i => i.id === item.id);
+      if (existing) {
+        return prev.map(i => i.id === item.id ? { ...i, quantity: i.quantity + item.quantity } : i);
+      }
+      return [...prev, item];
+    });
+  };
+
+  const removeItem = (id: string) => {
+    setItems(prev => prev.filter(i => i.id !== id));
+  };
+
+  const clear = () => setItems([]);
+
+  return (
+    <CartContext.Provider value={{ items, addItem, removeItem, clear }}>
+      {children}
+    </CartContext.Provider>
+  );
+}

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -7,3 +7,4 @@ export {
   useRequestQuoteWizard
 } from './RequestQuoteWizard';
 export { ViewModeProvider, useViewMode } from './ViewModeContext';
+export { CartProvider, useCart } from './CartContext';

--- a/tests/CartContext.test.tsx
+++ b/tests/CartContext.test.tsx
@@ -1,0 +1,32 @@
+import { renderHook, act } from '@testing-library/react';
+import { CartProvider, useCart } from '@/context/CartContext';
+
+test('add, remove and clear items', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <CartProvider>{children}</CartProvider>
+  );
+
+  const { result } = renderHook(() => useCart(), { wrapper });
+
+  act(() => {
+    result.current.addItem({ id: '1', quantity: 1 });
+  });
+
+  expect(result.current.items).toHaveLength(1);
+
+  act(() => {
+    result.current.addItem({ id: '1', quantity: 2 });
+  });
+  expect(result.current.items[0].quantity).toBe(3);
+
+  act(() => {
+    result.current.removeItem('1');
+  });
+  expect(result.current.items).toHaveLength(0);
+
+  act(() => {
+    result.current.addItem({ id: '2', quantity: 1 });
+    result.current.clear();
+  });
+  expect(result.current.items).toHaveLength(0);
+});

--- a/tests/QuoteWizard.test.tsx
+++ b/tests/QuoteWizard.test.tsx
@@ -1,6 +1,20 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { QuoteWizard } from '@/components/quote/QuoteWizard';
 import { RequestQuoteWizardProvider } from '@/context';
+import * as router from 'react-router-dom';
+import { toast } from '@/hooks/use-toast';
+
+jest.mock('react-router-dom', () => ({
+  ...(jest.requireActual('react-router-dom') as any),
+  useNavigate: jest.fn(),
+}));
+
+jest.mock('@/hooks/use-toast', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
 
 beforeEach(() => {
   global.fetch = jest.fn().mockResolvedValue({
@@ -32,4 +46,57 @@ test('advances to step 2 after selecting a service', async () => {
   fireEvent.click(screen.getByRole('button', { name: /continue/i }));
 
   expect(await screen.findByTestId('details-step')).toBeInTheDocument();
+});
+
+test('submits quote and navigates', async () => {
+  const navigateMock = jest.fn();
+  (router.useNavigate as jest.Mock).mockReturnValue(navigateMock);
+
+  (global.fetch as jest.Mock)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ id: '1', title: 'Service A' }],
+    })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+  setup();
+
+  const card = await screen.findByTestId('service-card-1');
+  fireEvent.click(card);
+  fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+  fireEvent.change(screen.getByTestId('message-input'), { target: { value: 'hi' } });
+  fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+  await screen.findByTestId('success-step');
+
+  expect(global.fetch).toHaveBeenCalledWith(
+    '/api/quotes',
+    expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ service_id: '1', user_message: 'hi' }),
+    })
+  );
+  expect(toast.success).toHaveBeenCalled();
+  expect(navigateMock).toHaveBeenCalledWith('/dashboard/quotes');
+});
+
+test('shows error message when fetch fails', async () => {
+  (global.fetch as jest.Mock).mockRejectedValue(new Error('fail'));
+  setup();
+  expect(await screen.findByText(/service temporarily unavailable/i)).toBeInTheDocument();
+});
+
+// ensures loading indicator appears before data loads
+// we check for spinner via class name on initial render
+// fetch promise never resolves
+
+test('shows loader while fetching', async () => {
+  (global.fetch as jest.Mock).mockImplementation(() => new Promise(() => {}));
+  const { container } = render(
+    <RequestQuoteWizardProvider>
+      <QuoteWizard />
+    </RequestQuoteWizardProvider>
+  );
+  expect(container.querySelector('.animate-spin')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add a simple CartContext with provider
- test CartContext hook logic
- expand QuoteWizard tests for loader and error handling
- add Cypress spec covering purchase flow in Stripe test mode
- run CI on all push events

## Testing
- `npm run test -- --coverage` *(fails: vitest not found)*
- `npm run cypress:run` *(fails: cypress not found)*