### PR TITLE
Add SEO configs and structured data

### DIFF
--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -1,0 +1,26 @@
+const config = {
+  titleTemplate: '%s | Zion Tech Marketplace',
+  defaultTitle: 'Zion Tech Marketplace',
+  description: 'Discover top tech talent, AI services and equipment.',
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    url: 'https://app.ziontechgroup.com',
+    siteName: 'Zion Tech Marketplace',
+    images: [
+      {
+        url: 'https://drive.google.com/uc?export=view&id=0B0iuzhpa3pD7X0RzZ2lmclN3Ymc',
+        width: 1200,
+        height: 630,
+        alt: 'Zion Tech Marketplace'
+      }
+    ]
+  },
+  twitter: {
+    handle: '@lovable_dev',
+    site: '@lovable_dev',
+    cardType: 'summary_large_image'
+  }
+};
+
+export default config;

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: 'https://app.ziontechgroup.com',
+  generateRobotsTxt: true,
+  outDir: './public'
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "NODE_ENV=production tsc && NODE_ENV=production vite build",
+    "postbuild": "next-sitemap",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "NODE_ENV=production vite preview",
     "test": "vitest",
@@ -70,7 +71,9 @@
     "tailwind-merge": "^2.2.1",
     "vaul": "^0.9.0",
     "zod": "^3.22.4",
-    "yup": "^1.2.0"
+    "yup": "^1.2.0",
+    "next-seo": "^6.0.0",
+    "next-sitemap": "^5.3.2"
   },
   "devDependencies": {
     "@testing-library/cypress": "^8.0.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,13 @@
+import type { AppProps } from 'next/app';
+import { DefaultSeo } from 'next-seo';
+import SEO from '../next-seo.config';
+import '../src/index.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <>
+      <DefaultSeo {...SEO} />
+      <Component {...pageProps} />
+    </>
+  );
+}

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -1,0 +1,14 @@
+import { Helmet } from 'react-helmet-async';
+
+interface StructuredDataProps {
+  data: Record<string, unknown>;
+}
+
+export function StructuredData({ data }: StructuredDataProps) {
+  const json = JSON.stringify(data);
+  return (
+    <Helmet>
+      <script type="application/ld+json">{json}</script>
+    </Helmet>
+  );
+}

--- a/src/pages/EquipmentDetail.tsx
+++ b/src/pages/EquipmentDetail.tsx
@@ -10,6 +10,8 @@ import { toast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { getStripe } from "@/utils/getStripe";
 import { safeStorage } from '@/utils/safeStorage';
+import { SEO } from "@/components/SEO";
+import { StructuredData } from "@/components/StructuredData";
 
 interface EquipmentSpecification {
   name: string;
@@ -220,8 +222,34 @@ export default function EquipmentDetail() {
     }
   };
 
+  const pageUrl = `https://app.ziontechgroup.com/equipment/${equipment.id}`;
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name: equipment.name,
+    description: equipment.description,
+    image: equipment.images,
+    brand: equipment.brand,
+    offers: {
+      '@type': 'Offer',
+      priceCurrency: equipment.currency,
+      price: equipment.price,
+      availability: equipment.inStock
+        ? 'https://schema.org/InStock'
+        : 'https://schema.org/OutOfStock',
+      url: pageUrl
+    }
+  };
+
   return (
     <>
+      <SEO
+        title={equipment.name}
+        description={equipment.description}
+        ogImage={equipment.images[0]}
+        canonical={pageUrl}
+      />
+      <StructuredData data={structuredData} />
       <div className="min-h-screen bg-zion-blue py-12 px-4">
         <div className="container mx-auto">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">

--- a/src/pages/TalentProfilePage.tsx
+++ b/src/pages/TalentProfilePage.tsx
@@ -15,6 +15,8 @@ import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/useAuth";
 import { UserProfile } from "@/types/auth";
 import { toast } from "@/hooks/use-toast";
+import { SEO } from "@/components/SEO";
+import { StructuredData } from "@/components/StructuredData";
 
 export default function TalentProfilePage() {
   // Cast to specify the expected route param type since useParams may be untyped
@@ -46,6 +48,19 @@ export default function TalentProfilePage() {
     updatedAt: new Date().toISOString(), // Default value since userDetails doesn't have this property
     role: '' // Default empty string since userDetails doesn't have this property
   };
+
+  const pageUrl = id ? `https://app.ziontechgroup.com/talent/${id}` : undefined;
+  const structuredData = profile ? {
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    serviceType: profile.title,
+    provider: {
+      '@type': 'Person',
+      name: profile.name
+    },
+    description: profile.bio,
+    url: pageUrl
+  } : null;
 
   // Handle loading error gracefully
   useEffect(() => {
@@ -93,9 +108,16 @@ export default function TalentProfilePage() {
   };
 
   return (
-    <div className="min-h-screen bg-zion-blue pb-12">
-      <TalentProfile 
-        profile={profile} 
+    <>
+      <SEO
+        title={profile ? `${profile.name} - ${profile.title}` : 'Talent Profile'}
+        description={profile?.bio || 'Talent profile on Zion'}
+        canonical={pageUrl}
+      />
+      {structuredData && <StructuredData data={structuredData} />}
+      <div className="min-h-screen bg-zion-blue pb-12">
+      <TalentProfile
+        profile={profile}
         onRequestHire={handleRequestHire}
         onMessageTalent={handleMessageTalent}
       />
@@ -139,5 +161,6 @@ export default function TalentProfilePage() {
         onClose={() => setIsMessageModalOpen(false)}
       />
     </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add `next-seo` configuration and custom `_app` with `DefaultSeo`
- generate sitemap and robots.txt via `next-sitemap`
- provide `StructuredData` helper
- add dynamic SEO tags for equipment and talent pages
- use a valid version for `next-sitemap`

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run build` *(fails: missing type definitions)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.