### PR TITLE
Fix component imports for pages and icons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,7 +49,7 @@ import ZionHireAI from './pages/ZionHireAI';
 import RequestQuotePage from './pages/RequestQuote';
 import WishlistPage from './pages/Wishlist';
 import CartPage from './pages/Cart';
-import CheckoutPage from './pages/Checkout';
+import Checkout from './pages/Checkout';
 
 const baseRoutes = [
   { path: '/', element: <Home /> },
@@ -81,7 +81,7 @@ const baseRoutes = [
   { path: '/blog/:slug', element: <BlogPost /> },
   { path: '/wishlist', element: <WishlistPage /> },
   { path: '/cart', element: <CartPage /> },
-  { path: '/checkout', element: <CheckoutPage /> },
+  { path: '/checkout', element: <Checkout /> },
 ];
 
 const App = () => {

--- a/src/components/header/MobileBottomNav.tsx
+++ b/src/components/header/MobileBottomNav.tsx
@@ -13,7 +13,7 @@ import {
   MessageSquare,
   ShoppingCart,
   User
-} from "@/components/icons";
+} from "lucide-react";
 
 interface MobileBottomNavProps {
   unreadCount?: number;

--- a/src/layout/MainNavigation.tsx
+++ b/src/layout/MainNavigation.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useTranslation } from "react-i18next";
 import { useFavorites } from "@/hooks/useFavorites";
 import { useCart } from "@/context/CartContext";
-import { Heart, MessageSquare, ShoppingCart } from "@/components/icons";
+import { Heart, MessageSquare, ShoppingCart } from "lucide-react";
 
 interface MainNavigationProps {
   isAdmin?: boolean;

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -29,7 +29,7 @@ interface CheckoutForm {
   country: string;
 }
 
-export default function CheckoutPage() {
+export default function Checkout() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const [items, setItems] = useState<CartItem[]>([]);


### PR DESCRIPTION
## Summary
- normalize Checkout page component name
- import icons directly from `lucide-react`

## Testing
- `npm test` *(fails: vitest not found)*