### PR TITLE
Add Stripe checkout docs

### DIFF
--- a/docs/Payments.md
+++ b/docs/Payments.md
@@ -7,3 +7,20 @@ The demo checkout flow uses Stripe in test mode. Configure these environment var
 - `VITE_STRIPE_PUBLISHABLE_KEY` – optional publishable key for production builds.
 
 Set them in `.env` or your hosting provider's environment configuration.
+
+## Example Checkout Flow
+
+To redirect customers to Stripe Checkout in test mode:
+
+```ts
+import { loadStripe } from '@stripe/stripe-js';
+
+// Use the publishable test key so no live charges occur
+const stripe = await loadStripe(import.meta.env.NEXT_PUBLIC_STRIPE_TEST_KEY);
+
+// Request a Checkout Session from your backend
+const session = await axios.post('/payments/create-session', { priceId });
+
+// Redirect the browser to the hosted Checkout page
+await stripe?.redirectToCheckout({ sessionId: session.data.id });
+```


### PR DESCRIPTION
## Summary
- document environment variables for Stripe
- add example code for using Stripe Checkout in test mode

## Testing
- `npm run test` *(fails: vitest not found)*