### PR TITLE
Add Firestore favorites hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "tailwind-merge": "^2.2.1",
     "vaul": "^0.9.0",
     "zod": "^3.22.4",
-    "yup": "^1.2.0"
+    "yup": "^1.2.0",
+    "firebase": "^9.23.0"
   },
   "devDependencies": {
     "@testing-library/cypress": "^8.0.2",

--- a/src/hooks/useFirestoreFavorites.ts
+++ b/src/hooks/useFirestoreFavorites.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react';
+import { doc, getDoc, setDoc, deleteDoc, serverTimestamp, collection, getDocs } from 'firebase/firestore';
+import { db } from '@/integrations/firebase/client';
+import { useAuth } from './useAuth';
+
+export interface FirestoreFavorite {
+  id: string;
+  created?: any;
+}
+
+export function useFirestoreFavorites() {
+  const { user } = useAuth();
+  const [favorites, setFavorites] = useState<FirestoreFavorite[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchFavorites = async () => {
+      if (!user) {
+        setFavorites([]);
+        setLoading(false);
+        return;
+      }
+      const favCol = collection(db, 'users', (user as any).uid || (user as any).id, 'favorites');
+      const snapshot = await getDocs(favCol);
+      setFavorites(snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as any) })));
+      setLoading(false);
+    };
+    fetchFavorites();
+  }, [user]);
+
+  const toggleFavorite = async (listingId: string) => {
+    if (!user) return;
+    const uid = (user as any).uid || (user as any).id;
+    const favRef = doc(db, 'users', uid, 'favorites', listingId);
+    const exists = (await getDoc(favRef)).exists();
+    if (exists) {
+      await deleteDoc(favRef);
+      setFavorites(prev => prev.filter(f => f.id !== listingId));
+    } else {
+      await setDoc(favRef, { created: serverTimestamp() });
+      setFavorites(prev => [...prev, { id: listingId }]);
+    }
+  };
+
+  return { favorites, loading, toggleFavorite };
+}

--- a/src/integrations/firebase/client.ts
+++ b/src/integrations/firebase/client.ts
@@ -1,0 +1,15 @@
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+
+export const db = getFirestore(app);


### PR DESCRIPTION
## Summary
- add Firebase as dependency
- add Firestore client initialization
- implement `useFirestoreFavorites` hook with Firestore toggle logic

## Testing
- `npm run test` *(fails: vitest not found)*