### PR TITLE
Implement single toggle for list/grid view

### DIFF
--- a/src/components/DynamicListingPage.tsx
+++ b/src/components/DynamicListingPage.tsx
@@ -53,6 +53,13 @@ export function DynamicListingPage({
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [view, setView] = useState<ListingView>("grid");
+  const isGrid = view === "grid";
+  // Swap icons to match action
+  const ToggleViewIcon = isGrid ? (
+    <List className="h-4 w-4" />
+  ) : (
+    <LayoutGrid className="h-4 w-4" />
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [priceRange, setPriceRange] = useState<PriceRange>(initialPrice);
 
@@ -277,34 +284,13 @@ export function DynamicListingPage({
                   <Button
                     variant="outline"
                     size="icon"
-                    onClick={() => setView("grid")}
-                    aria-pressed={view === "grid"}
-                    aria-label="Grid view"
-                    title="Grid view"
-                    className={`${
-                      view === "grid"
-                        ? "bg-zion-purple/30 border-zion-purple text-zion-purple"
-                        : "border-zion-blue-light text-zion-slate-light"
-                    } focus-visible:ring-zion-purple`}
+                    onClick={() => setView(isGrid ? "list" : "grid")}
+                    aria-label={isGrid ? "List view" : "Grid view"}
+                    title={isGrid ? "List view" : "Grid view"}
+                    className="border-zion-blue-light text-zion-slate-light focus-visible:ring-zion-purple"
                   >
-                    <LayoutGrid className="h-4 w-4" />
-                    <span className="sr-only">Grid view</span>
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="icon"
-                    onClick={() => setView("list")}
-                    aria-pressed={view === "list"}
-                    aria-label="List view"
-                    title="List view"
-                    className={`${
-                      view === "list"
-                        ? "bg-zion-purple/30 border-zion-purple text-zion-purple"
-                        : "border-zion-blue-light text-zion-slate-light"
-                    } focus-visible:ring-zion-purple`}
-                  >
-                    <List className="h-4 w-4" />
-                    <span className="sr-only">List view</span>
+                    {ToggleViewIcon}
+                    <span className="sr-only">{isGrid ? "List view" : "Grid view"}</span>
                   </Button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add `ToggleViewIcon` for swapping icons based on view
- replace two view buttons with single toggle button in `DynamicListingPage`

## Testing
- `npm run test` *(fails: vitest not found)*