### PR TITLE
Add retry utility and env based API baseURL

### DIFF
--- a/src/pages/ServicesPage.tsx
+++ b/src/pages/ServicesPage.tsx
@@ -8,6 +8,7 @@ import { Link } from "react-router-dom";
 import { Globe } from "lucide-react";
 import { useEffect, useState } from "react";
 import apiClient from "@/services/apiClient";
+import retry from "@/utils/retry";
 
 
 function getRandomItem<T>(arr: T[]): T {
@@ -114,7 +115,10 @@ export default function ServicesPage() {
 
   useEffect(() => {
     async function load() {
-      const res = await apiClient.get('/services');
+      const res = await retry(() => apiClient.get('/services'), {
+        retries: 3,
+        minTimeout: 500,
+      });
       setListings(res.data as ProductListing[]);
     }
     load();

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -4,7 +4,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { captureException } from '@/utils/sentry';
 
 const apiClient = axios.create({
-  baseURL: '/api',
+  baseURL: import.meta.env.VITE_API_URL || '/api',
   withCredentials: true,
 });
 

--- a/src/types/vite-env.d.ts
+++ b/src/types/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_SUPABASE_ANON_KEY: string;
   readonly NEXT_PUBLIC_SUPABASE_URL?: string;
   readonly NEXT_PUBLIC_SUPABASE_ANON_KEY?: string;
+  readonly VITE_API_URL?: string;
   // add more env variables as needed
 }
 

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,21 @@
+export interface RetryOptions {
+  retries?: number;
+  minTimeout?: number;
+}
+
+export async function retry<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
+  const { retries = 3, minTimeout = 500 } = options;
+  let attempt = 0;
+  while (true) {
+    try {
+      return await fn();
+    } catch (err) {
+      attempt++;
+      if (attempt > retries) throw err;
+      const delay = Math.pow(2, attempt - 1) * minTimeout;
+      await new Promise((res) => setTimeout(res, delay));
+    }
+  }
+}
+
+export default retry;


### PR DESCRIPTION
## Summary
- support a new `VITE_API_URL` env variable
- allow the Axios client to use the env base URL
- provide a small retry helper implementing exponential backoff
- use the retry helper when loading services on the Services page

## Testing
- `npm run test` *(fails: vitest not found)*