### PR TITLE
Add Mailchimp integration and newsletter opt-in

### DIFF
--- a/src/integrations/mailchimp/MailchimpService.ts
+++ b/src/integrations/mailchimp/MailchimpService.ts
@@ -1,0 +1,94 @@
+export interface MailchimpMember {
+  email: string;
+  mergeFields?: Record<string, string>;
+}
+
+/**
+ * Basic Mailchimp API wrapper used on both the client and Supabase edge
+ * functions.  It performs simple authenticated fetch requests using the
+ * provided API key.  Only minimal functionality needed by the app is
+ * implemented.
+ */
+export class MailchimpService {
+  private apiKey: string;
+  private baseUrl: string;
+  private listId: string;
+
+  constructor(apiKey: string, listId: string) {
+    if (!apiKey) throw new Error('Mailchimp API key missing');
+    if (!listId) throw new Error('Mailchimp list ID missing');
+    this.apiKey = apiKey;
+    const dc = apiKey.split('-')[1];
+    this.baseUrl = `https://${dc}.api.mailchimp.com/3.0`;
+    this.listId = listId;
+  }
+
+  /**
+   * Low level request helper exposed for edge function usage.
+   */
+  async request(path: string, options: RequestInit = {}) {
+    const res = await fetch(this.baseUrl + path, {
+      ...options,
+      headers: {
+        Authorization: `apikey ${this.apiKey}`,
+        'Content-Type': 'application/json',
+        ...(options.headers || {})
+      }
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`Mailchimp error: ${res.status} ${text}`);
+    }
+    return res.json().catch(() => ({}));
+  }
+
+  /**
+   * Subscribe a new member to the list.
+   */
+  async addSubscriber(member: MailchimpMember) {
+    return this.request(`/lists/${this.listId}/members`, {
+      method: 'POST',
+      body: JSON.stringify({
+        email_address: member.email,
+        status: 'subscribed',
+        merge_fields: member.mergeFields || {}
+      })
+    });
+  }
+
+  /**
+   * Upsert a member in the list, used for nightly sync jobs.
+   */
+  async upsertMember(member: MailchimpMember) {
+    const crypto = await import('crypto');
+    const hash = crypto.createHash('md5').update(member.email.toLowerCase()).digest('hex');
+    return this.request(`/lists/${this.listId}/members/${hash}`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        email_address: member.email,
+        status_if_new: 'subscribed',
+        merge_fields: member.mergeFields || {}
+      })
+    });
+  }
+
+  /**
+   * Trigger a welcome email automation with a discount coupon.
+   * This assumes an automation is configured in Mailchimp that will send
+   * the email when a request is queued.
+   */
+  async sendWelcomeEmail(email: string, coupon: string) {
+    return this.request(`/automations/welcome/emails/1/queue`, {
+      method: 'POST',
+      body: JSON.stringify({ email_address: email, coupon })
+    });
+  }
+
+  /**
+   * Export a segment by ID. Used by the scheduled export job.
+   */
+  async exportSegment(segmentId: string) {
+    return this.request(`/lists/${this.listId}/segments/${segmentId}/members`);
+  }
+}

--- a/src/integrations/mailchimp/index.ts
+++ b/src/integrations/mailchimp/index.ts
@@ -1,0 +1,16 @@
+import { MailchimpService } from './MailchimpService';
+
+const apiKey =
+  import.meta.env.VITE_MAILCHIMP_API_KEY ||
+  (import.meta.env as any).NEXT_PUBLIC_MAILCHIMP_API_KEY ||
+  process.env.MAILCHIMP_API_KEY;
+
+const listId =
+  import.meta.env.VITE_MAILCHIMP_LIST_ID ||
+  (import.meta.env as any).NEXT_PUBLIC_MAILCHIMP_LIST_ID ||
+  process.env.MAILCHIMP_LIST_ID;
+
+export const mailchimpService =
+  apiKey && listId ? new MailchimpService(apiKey, listId) : undefined;
+
+export type { MailchimpMember } from './MailchimpService';

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -15,6 +15,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { PasswordStrengthMeter } from "@/components/PasswordStrengthMeter";
 import { safeStorage } from "@/utils/safeStorage";
+import { mailchimpService } from "@/integrations/mailchimp";
 import {
   Form,
   FormControl,
@@ -38,6 +39,7 @@ const signupSchema = z
     termsAccepted: z.boolean().refine(val => val === true, {
       message: "You must accept the terms and conditions",
     }),
+    newsletterOptIn: z.boolean().optional(),
   })
   .refine(data => data.password === data.confirmPassword, {
     message: "Passwords do not match",
@@ -64,6 +66,7 @@ export default function Signup() {
       password: "",
       confirmPassword: "",
       termsAccepted: false,
+      newsletterOptIn: false,
     },
   }) as UseFormReturn<SignupFormValues>;
 
@@ -103,6 +106,19 @@ export default function Signup() {
 
       if (resData?.token) {
         safeStorage.setItem("token", resData.token);
+      }
+
+      // Subscribe user to Mailchimp if opted in
+      if (data.newsletterOptIn && mailchimpService) {
+        try {
+          await mailchimpService.addSubscriber({
+            email: data.email,
+            mergeFields: { FNAME: data.displayName }
+          });
+          await mailchimpService.sendWelcomeEmail(data.email, 'NEW10');
+        } catch (err) {
+          console.error('Mailchimp subscription failed', err);
+        }
       }
 
       toast.success("Welcome to ZionAI 🎉");
@@ -301,6 +317,27 @@ export default function Signup() {
                   />
 
                   <PasswordStrengthMeter password={passwordValue} />
+
+                  <FormField
+                    control={form.control}
+                    name="newsletterOptIn"
+                    render={({ field }) => (
+                      <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                        <FormControl>
+                          <Checkbox
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                            className="data-[state=checked]:bg-zion-purple data-[state=checked]:border-zion-purple"
+                          />
+                        </FormControl>
+                        <div className="space-y-1 leading-none">
+                          <FormLabel className="text-sm text-zion-slate-light">
+                            Subscribe to our newsletter
+                          </FormLabel>
+                        </div>
+                      </FormItem>
+                    )}
+                  />
 
                   <FormField
                     control={form.control}

--- a/supabase/functions/mailchimp-export-segments/index.ts
+++ b/supabase/functions/mailchimp-export-segments/index.ts
@@ -1,0 +1,41 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { MailchimpService } from "../../..//src/integrations/mailchimp/MailchimpService.ts";
+
+serve(async () => {
+  try {
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+    );
+    const apiKey = Deno.env.get("MAILCHIMP_API_KEY") ?? "";
+    const listId = Deno.env.get("MAILCHIMP_LIST_ID") ?? "";
+    const mailchimp = new MailchimpService(apiKey, listId);
+
+    // Example segmentation based on total purchase amount
+    const { data: users } = await supabase
+      .rpc('get_purchase_totals'); // assume a stored procedure
+
+    for (const seg of users || []) {
+      const segmentName = seg.segment;
+      const emails = seg.emails as string[];
+
+      // Create static segment in Mailchimp
+      await mailchimp.request(`/lists/${listId}/segments`, {
+        method: 'POST',
+        body: JSON.stringify({ name: segmentName, static_segment: emails })
+      });
+    }
+
+    return new Response(JSON.stringify({ exported: (users || []).length }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  } catch (err) {
+    console.error('mailchimp-export-segments error', err);
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+});

--- a/supabase/functions/mailchimp-sync-new-users/index.ts
+++ b/supabase/functions/mailchimp-sync-new-users/index.ts
@@ -1,0 +1,43 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { MailchimpService } from "../../..//src/integrations/mailchimp/MailchimpService.ts";
+
+serve(async (req) => {
+  try {
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+    );
+
+    const apiKey = Deno.env.get("MAILCHIMP_API_KEY") ?? "";
+    const listId = Deno.env.get("MAILCHIMP_LIST_ID") ?? "";
+    const mailchimp = new MailchimpService(apiKey, listId);
+
+    // Fetch users created in the last 24 hours
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const { data: users, error } = await supabase
+      .from("profiles")
+      .select("email, display_name")
+      .gt("created_at", since);
+
+    if (error) throw error;
+
+    for (const u of users || []) {
+      await mailchimp.upsertMember({
+        email: u.email,
+        mergeFields: { FNAME: u.display_name }
+      });
+    }
+
+    return new Response(
+      JSON.stringify({ synced: users?.length || 0 }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    console.error("mailchimp-sync-new-users error", err);
+    return new Response(
+      JSON.stringify({ error: err.message }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add MailchimpService utility for basic API operations
- expose configured instance in `src/integrations/mailchimp`
- allow sign-up to opt-in to newsletter and subscribe via Mailchimp
- trigger welcome email coupon on sign-up
- add Supabase edge functions for nightly sync and segment export

## Testing
- `npm run test` *(fails: vitest not found)*