### PR TITLE
Fix signup endpoint and Vite alias resolution

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import Sitemap from './pages/Sitemap';
 import PartnersPage from './pages/Partners';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
+import SignUp from './pages/SignUp';
 import ITOnsiteServicesPage from './pages/ITOnsiteServicesPage';
 import OpenAppRedirect from './pages/OpenAppRedirect';
 import ContactPage from './pages/Contact';
@@ -56,7 +57,7 @@ const baseRoutes = [
   { path: '/match', element: <AIMatcherPage /> },
   { path: '/login', element: <Login /> },
   { path: '/register', element: <Signup /> },
-  { path: '/signup', element: <Signup /> },
+  { path: '/signup', element: <SignUp /> },
   { path: '/talent', element: <TalentDirectory /> },
   { path: '/talents', element: <TalentsPage /> },
   { path: '/more-talents', element: <MoreTalentsPage /> },

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+
+export default function SignUp() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await axios.post('/api/auth/register', { email, password });
+    navigate('/marketplace');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 space-y-2">
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+        className="border px-2 py-1 w-full"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+        className="border px-2 py-1 w-full"
+      />
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+        Sign Up
+      </button>
+    </form>
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { SAMPLE_SERVICES } from './src/data/sampleServices'
+
+const srcDir = fileURLToPath(new URL('./src', import.meta.url))
+const axiosPath = fileURLToPath(new URL('./src/lib/axios.ts', import.meta.url))
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -37,8 +40,8 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
-      'axios': path.resolve(__dirname, './src/lib/axios.ts')
+      '@': srcDir,
+      'axios': axiosPath
     }
   },
   server: {


### PR DESCRIPTION
## Summary
- use `/api/auth/register` endpoint in SignUp page
- update Vite config aliases using `import.meta` to avoid build errors

## Testing
- `npm run test` *(fails: vitest not found)*