### PR TITLE
Add API key model and portal

### DIFF
--- a/backend/django_backend/settings.py
+++ b/backend/django_backend/settings.py
@@ -13,7 +13,10 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
+    'drf_yasg',
     'authentication',
+    'public_api',
 ]
 
 MIDDLEWARE = [
@@ -61,9 +64,35 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+        'LOCATION': os.environ.get('REDIS_URL', 'redis://127.0.0.1:6379/1'),
+    }
+}
+
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 EMAIL_BACKEND = 'sendgrid_backend.SendgridBackend'
 SENDGRID_API_KEY = os.environ.get('SENDGRID_API_KEY')
 
 PASSWORD_RESET_TIMEOUT = 900  # 15 minutes
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'public_api.authentication.ApiKeyAuthentication',
+    ],
+    'DEFAULT_THROTTLE_CLASSES': [
+        'public_api.throttling.RedisDailyThrottle',
+    ],
+}
+
+SWAGGER_SETTINGS = {
+    'SECURITY_DEFINITIONS': {
+        'ApiKeyAuth': {
+            'type': 'apiKey',
+            'in': 'header',
+            'name': 'X-API-KEY'
+        }
+    }
+}

--- a/backend/django_backend/urls.py
+++ b/backend/django_backend/urls.py
@@ -1,5 +1,16 @@
 from django.urls import path, include
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+from rest_framework.permissions import AllowAny
+
+schema_view = get_schema_view(
+    openapi.Info(title="Public API", default_version='v1'),
+    public=True,
+    permission_classes=[AllowAny],
+)
 
 urlpatterns = [
     path('auth/', include('authentication.urls')),
+    path('api/', include('public_api.urls')),
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='swagger-ui'),
 ]

--- a/backend/public_api/__init__.py
+++ b/backend/public_api/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'public_api.apps.PublicApiConfig'

--- a/backend/public_api/apps.py
+++ b/backend/public_api/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class PublicApiConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'public_api'

--- a/backend/public_api/authentication.py
+++ b/backend/public_api/authentication.py
@@ -1,0 +1,24 @@
+from hashlib import sha256
+from django.utils.translation import gettext_lazy as _
+from rest_framework.authentication import BaseAuthentication
+from rest_framework import exceptions
+from .models import ApiKey
+
+class ApiKeyAuthentication(BaseAuthentication):
+    keyword = 'Api-Key'
+
+    def authenticate(self, request):
+        key = request.headers.get('X-API-KEY') or request.headers.get('Authorization')
+        if not key:
+            return None
+        if key.startswith(self.keyword + ' '):
+            key = key[len(self.keyword) + 1:]
+        prefix = key[:8]
+        try:
+            api_key = ApiKey.objects.get(prefix=prefix, revoked=False)
+        except ApiKey.DoesNotExist:
+            raise exceptions.AuthenticationFailed(_('Invalid API key'))
+        digest = sha256(key.encode()).hexdigest()
+        if digest != api_key.hashed_key:
+            raise exceptions.AuthenticationFailed(_('Invalid API key'))
+        return (api_key.user, None)

--- a/backend/public_api/models.py
+++ b/backend/public_api/models.py
@@ -1,0 +1,13 @@
+from django.db import models
+from django.contrib.auth import get_user_model
+
+class ApiKey(models.Model):
+    user = models.ForeignKey(get_user_model(), on_delete=models.CASCADE)
+    prefix = models.CharField(max_length=8, unique=True)
+    hashed_key = models.CharField(max_length=64)
+    rate_limit = models.IntegerField(default=1000)
+    created_at = models.DateTimeField(auto_now_add=True)
+    revoked = models.BooleanField(default=False)
+
+    def __str__(self):
+        return f"{self.prefix} for {self.user}" 

--- a/backend/public_api/templates/developer_portal.html
+++ b/backend/public_api/templates/developer_portal.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Developer Portal</title>
+</head>
+<body>
+<h1>Developer Portal</h1>
+{% if new_key %}
+<p>Your new API key: <strong>{{ new_key }}</strong></p>
+{% endif %}
+<form method="post">
+  {% csrf_token %}
+  <button type="submit" name="generate">Generate Key</button>
+</form>
+<h2>Your Keys</h2>
+<ul>
+{% for key in keys %}
+  <li>{{ key.prefix }}
+      <form method="post" style="display:inline;">
+        {% csrf_token %}
+        <input type="hidden" name="prefix" value="{{ key.prefix }}" />
+        <button type="submit" name="revoke">Revoke</button>
+      </form>
+  </li>
+{% empty %}
+  <li>No keys</li>
+{% endfor %}
+</ul>
+</body>
+</html>

--- a/backend/public_api/throttling.py
+++ b/backend/public_api/throttling.py
@@ -1,0 +1,16 @@
+from datetime import timedelta
+from django.core.cache import cache
+from rest_framework.throttling import SimpleRateThrottle
+
+class RedisDailyThrottle(SimpleRateThrottle):
+    scope = 'daily'
+    rate = '1000/day'
+
+    def get_cache_key(self, request, view):
+        ident = request.user.pk if request.user.is_authenticated else request.META.get('REMOTE_ADDR')
+        if not ident:
+            return None
+        return self.cache_format % {
+            'scope': self.scope,
+            'ident': ident
+        }

--- a/backend/public_api/urls.py
+++ b/backend/public_api/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('generate/', views.generate_key, name='generate_key'),
+    path('revoke/', views.revoke_key, name='revoke_key'),
+    path('ping/', views.protected_endpoint, name='protected'),
+    path('developer/', views.developer_portal, name='developer_portal'),
+]

--- a/backend/public_api/views.py
+++ b/backend/public_api/views.py
@@ -1,0 +1,50 @@
+import secrets
+from hashlib import sha256
+from rest_framework.decorators import api_view, permission_classes, authentication_classes, throttle_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework import status
+from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
+
+from .models import ApiKey
+from .authentication import ApiKeyAuthentication
+from .throttling import RedisDailyThrottle
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def generate_key(request):
+    prefix = secrets.token_hex(4)
+    full_key = prefix + secrets.token_hex(16)
+    hashed = sha256(full_key.encode()).hexdigest()
+    ApiKey.objects.create(user=request.user, prefix=prefix, hashed_key=hashed)
+    return Response({'key': full_key, 'prefix': prefix}, status=status.HTTP_201_CREATED)
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def revoke_key(request):
+    prefix = request.data.get('prefix')
+    ApiKey.objects.filter(user=request.user, prefix=prefix).update(revoked=True)
+    return Response({'detail': 'revoked'})
+
+@api_view(['GET'])
+@authentication_classes([ApiKeyAuthentication])
+@throttle_classes([RedisDailyThrottle])
+def protected_endpoint(request):
+    return Response({'detail': 'success'})
+
+
+@login_required
+def developer_portal(request):
+    context = {}
+    if request.method == 'POST' and 'generate' in request.POST:
+        prefix = secrets.token_hex(4)
+        full_key = prefix + secrets.token_hex(16)
+        hashed = sha256(full_key.encode()).hexdigest()
+        ApiKey.objects.create(user=request.user, prefix=prefix, hashed_key=hashed)
+        context['new_key'] = full_key
+    if request.method == 'POST' and 'revoke' in request.POST:
+        pref = request.POST.get('prefix')
+        ApiKey.objects.filter(user=request.user, prefix=pref).update(revoked=True)
+    context['keys'] = ApiKey.objects.filter(user=request.user, revoked=False)
+    return render(request, 'developer_portal.html', context)


### PR DESCRIPTION
## Summary
- add `public_api` Django app with API key model and throttle
- expose developer portal endpoints with Swagger UI
- configure REST framework and Redis cache

## Testing
- `npm run test` *(fails: vitest not found)*