### PR TITLE
Add help center and chatbot

### DIFF
--- a/docs/help/getting-started.md
+++ b/docs/help/getting-started.md
@@ -1,0 +1,7 @@
+# Getting Started
+
+Welcome to the Zion Help Center. This knowledge base contains articles to help you use the platform.
+
+## Tracking your order
+
+To check the status of an order, note your order ID and provide it when asked. You can also ask our chatbot about your order status.

--- a/pages/api/help/articles.ts
+++ b/pages/api/help/articles.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+
+interface Req { method?: string; query?: { q?: string } }
+interface JsonRes { status: (code: number) => JsonRes; json: (data: any) => void; end: () => void; }
+
+export default function handler(req: Req, res: JsonRes) {
+  if (req.method !== 'GET') { res.status(405).end(); return; }
+  const search = (req.query?.q || '').toLowerCase();
+  // Avoid TypeScript complaints about process.cwd() in environments where Node
+  // types are not available by falling back to '.' if the function is missing.
+  const cwd = (process as any).cwd ? (process as any).cwd() : '.';
+  const dir = path.join(cwd, 'docs/help');
+  const files = fs.readdirSync(dir);
+  const articles = files.filter(f => f.endsWith('.md')).map(f => {
+    const content = fs.readFileSync(path.join(dir, f), 'utf8');
+    const slug = f.replace(/\.md$/, '');
+    const titleMatch = content.match(/^#\s+(.*)/);
+    const title = titleMatch ? titleMatch[1] : slug;
+    return { slug, title, content };
+  });
+  const filtered = search
+    ? articles.filter(a => a.title.toLowerCase().includes(search) || a.content.toLowerCase().includes(search))
+    : articles;
+  res.status(200).json(filtered);
+}

--- a/pages/api/kb-chat.ts
+++ b/pages/api/kb-chat.ts
@@ -1,0 +1,57 @@
+// Generic request/response interfaces used in other API routes so the
+// handler works in various runtimes (Node, Edge, etc.) without relying on
+// Next.js specific types.
+type Req = {
+  method?: string;
+  body?: any;
+  headers: Record<string, string | undefined>;
+  query?: Record<string, string | undefined>;
+  url?: string;
+};
+interface JsonRes {
+  status: (code: number) => JsonRes;
+  json: (data: any) => void;
+  end: (data?: any) => void;
+  setHeader?: (name: string, value: string) => void;
+}
+export default async function handler(req: Req, res: JsonRes) {
+  if (req.method !== 'POST') { res.status(405).end(); return; }
+  try {
+    const { messages } = req.body as { messages: { role: string; content: string }[] };
+    const last = messages[messages.length - 1]?.content || '';
+    const orderMatch = last.match(/order\s*(?:status)?\s*#?(\d+)/i);
+    if (/order status/i.test(last) && orderMatch) {
+      const orderId = orderMatch[1];
+      const base = req.headers.origin || `http://${req.headers.host}`;
+      const orderRes = await fetch(`${base}/api/orders/${orderId}`);
+      if (orderRes.ok) {
+        const order = await orderRes.json();
+        res.status(200).json({ message: `Order ${order.id} status is ${order.status}.`, confidence: 1 });
+        return;
+      }
+    }
+
+    const apiKey = process.env.OPENAI_API_KEY;
+    const openRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o',
+        messages,
+        temperature: 0.3
+      })
+    });
+    const data = await openRes.json();
+    const answer = data.choices?.[0]?.message?.content || 'Sorry, I am not sure.';
+    const confidence = data.choices?.[0]?.finish_reason === 'stop' ? 0.8 : 0.5;
+    if (confidence < 0.6) {
+      console.log('Escalating to Zendesk');
+    }
+    res.status(200).json({ message: answer, confidence });
+  } catch (e: any) {
+    res.status(500).json({ error: e.message });
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import NewProductsPage from './pages/NewProductsPage';
 import NewServicesPage from './pages/NewServicesPage';
 import Sitemap from './pages/Sitemap';
 import PartnersPage from './pages/Partners';
+import Help from './pages/Help';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
 import ITOnsiteServicesPage from './pages/ITOnsiteServicesPage';
@@ -50,6 +51,7 @@ import RequestQuotePage from './pages/RequestQuote';
 import WishlistPage from './pages/Wishlist';
 import CartPage from './pages/Cart';
 import Checkout from './pages/Checkout';
+import { SupportChatbot } from './components/SupportChatbot';
 
 const baseRoutes = [
   { path: '/', element: <Home /> },
@@ -74,6 +76,7 @@ const baseRoutes = [
   { path: '/contact', element: <ContactPage /> },
   { path: '/partners', element: <PartnersPage /> },
   { path: '/sitemap', element: <Sitemap /> },
+  { path: '/help', element: <Help /> },
   { path: '/zion-hire-ai', element: <ZionHireAI /> },
   { path: '/hire-ai', element: <ZionHireAI /> },
   { path: '/request-quote', element: <RequestQuotePage /> },
@@ -114,6 +117,7 @@ const App = () => {
         </Suspense>
         <Toaster />
         <SonnerToaster position="top-right" />
+        <SupportChatbot />
         <PwaInstallButton />
       </ThemeProvider>
     </WhitelabelProvider>

--- a/src/components/SupportChatbot.tsx
+++ b/src/components/SupportChatbot.tsx
@@ -1,0 +1,60 @@
+import { useState, useRef, useEffect } from 'react';
+import { MessageSquare, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ChatMessage, ChatInput } from '@/components/ChatAssistant';
+
+interface Msg { id: string; role: 'user' | 'assistant'; message: string; }
+
+export function SupportChatbot() {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<Msg[]>([]);
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => { endRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [messages]);
+
+  const sendMessage = async (text: string) => {
+    const userMsg: Msg = { id: Date.now().toString(), role: 'user', message: text };
+    setMessages(prev => [...prev, userMsg]);
+    try {
+      const res = await fetch('/api/kb-chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: [...messages.map(m => ({ role: m.role, content: m.message })), { role: 'user', content: text }] })
+      });
+      const data = await res.json();
+      const botMsg: Msg = { id: Date.now().toString() + '-a', role: 'assistant', message: data.message };
+      setMessages(prev => [...prev, botMsg]);
+    } catch (err) {
+      console.error(err);
+      setMessages(prev => [...prev, { id: Date.now().toString() + '-e', role: 'assistant', message: 'Sorry, something went wrong.' }]);
+    }
+  };
+
+  if (!open) {
+    return (
+      <Button onClick={() => setOpen(true)} size="icon" variant="outline" className="fixed bottom-4 right-4 h-12 w-12 rounded-full shadow-lg bg-zion-purple text-white hover:bg-zion-purple-light z-50" aria-label="Open help chat">
+        <MessageSquare className="h-5 w-5" />
+      </Button>
+    );
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 bg-zion-blue w-80 max-w-full rounded-lg shadow-xl flex flex-col z-50">
+      <div className="bg-zion-blue-dark p-2 flex justify-between items-center">
+        <span className="text-white font-medium">Help Bot</span>
+        <Button variant="ghost" size="icon" className="text-white" onClick={() => setOpen(false)}>
+          <X className="h-5 w-5" />
+        </Button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-3 space-y-4" style={{ maxHeight: '400px' }}>
+        {messages.map(m => (
+          <ChatMessage key={m.id} role={m.role} message={m.message} />
+        ))}
+        <div ref={endRef} />
+      </div>
+      <div className="p-2 border-t border-zion-purple/20 bg-zion-blue-dark/30">
+        <ChatInput onSend={sendMessage} />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react';
+import { Header } from '@/components/Header';
+import { Footer } from '@/components/Footer';
+import { GradientHeading } from '@/components/GradientHeading';
+import { Input } from '@/components/ui/input';
+import { Markdown } from '@/components/ui/markdown';
+import { SEO } from '@/components/SEO';
+import { SupportChatbot } from '@/components/SupportChatbot';
+
+interface Article { slug: string; title: string; content: string; }
+
+export default function Help() {
+  const [query, setQuery] = useState('');
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [selected, setSelected] = useState<Article | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/help/articles?q=${encodeURIComponent(query)}`)
+      .then(r => r.json())
+      .then(setArticles)
+      .catch(() => setArticles([]));
+  }, [query]);
+
+  return (
+    <>
+      <SEO title="Help Center" description="Search our knowledge base" />
+      <Header />
+      <main className="min-h-screen bg-zion-blue pt-24 pb-20">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-8">
+            <GradientHeading>Help Center</GradientHeading>
+            <p className="mt-4 text-zion-slate-light text-xl max-w-3xl mx-auto">Find answers to common questions.</p>
+          </div>
+          <div className="max-w-2xl mx-auto mb-8">
+            <Input
+              placeholder="Search articles..."
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              className="bg-zion-blue-light text-white"
+            />
+          </div>
+          <div className="grid gap-4 max-w-3xl mx-auto">
+            {articles.map(a => (
+              <button key={a.slug} onClick={() => setSelected(a)} className="text-left p-4 border border-zion-blue-light rounded text-white bg-zion-blue-dark hover:bg-zion-blue-light">
+                {a.title}
+              </button>
+            ))}
+          </div>
+          {selected && (
+            <div className="max-w-3xl mx-auto mt-8">
+              <h2 className="text-2xl font-bold text-white mb-4">{selected.title}</h2>
+              <Markdown content={selected.content} />
+            </div>
+          )}
+        </div>
+      </main>
+      <SupportChatbot />
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create **/help** page and bottom-right SupportChatbot component
- implement API routes for knowledge base articles and chatbot
- add a sample knowledge base article
- fix TypeScript interfaces and imports for serverless build

## Testing
- `./setup.sh npm` *(fails: EHOSTUNREACH)*
- `npm run test` *(fails: vitest not found)*