### PR TITLE
Fix CSP for eval usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
     <!-- Structured data (JSON-LD) for SEO -->
     <meta
       http-equiv="Content-Security-Policy"
+      content="script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.gpteng.co"
     />
     <script type="application/ld+json">
       {


### PR DESCRIPTION
## Summary
- enable `unsafe-eval` in index.html CSP

## Testing
- `npm test` *(fails: vitest not found)*