### PR TITLE
Add loader and error UI to Talent directory

### DIFF
--- a/src/components/talent/ErrorBanner.tsx
+++ b/src/components/talent/ErrorBanner.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+interface ErrorBannerProps {
+  msg: string;
+}
+
+export function ErrorBanner({ msg }: ErrorBannerProps) {
+  return (
+    <div className="p-4 bg-red-500/20 text-red-400 text-center rounded-md">
+      {msg}
+    </div>
+  );
+}

--- a/src/components/talent/TalentSkeleton.tsx
+++ b/src/components/talent/TalentSkeleton.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function TalentSkeleton() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div
+          key={i}
+          className="p-6 space-y-4 border border-zion-blue-light bg-zion-blue-dark rounded-lg"
+        >
+          <div className="flex items-center space-x-4">
+            <Skeleton className="w-16 h-16 rounded-full bg-zion-blue-light/20" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-3/4 bg-zion-blue-light/20" />
+              <Skeleton className="h-3 w-1/2 bg-zion-blue-light/20" />
+            </div>
+          </div>
+          <Skeleton className="h-24 w-full bg-zion-blue-light/20" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/talent/useFilterTalents.ts
+++ b/src/hooks/talent/useFilterTalents.ts
@@ -1,8 +1,7 @@
 
 import { useState, useMemo } from 'react';
 import { TalentProfile } from '@/types/talent';
-
-export function useFilterTalents(talents: TalentProfile[]) {
+export function useFilterTalents(talents: TalentProfile[] = []) {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
   const [selectedAvailability, setSelectedAvailability] = useState<string[]>([]);

--- a/src/hooks/talent/useTalentData.ts
+++ b/src/hooks/talent/useTalentData.ts
@@ -1,17 +1,27 @@
 
-import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { TALENT_PROFILES } from '@/data/talentData';
 import { TalentProfile } from '@/types/talent';
 
+async function fetchTalentProfiles(): Promise<TalentProfile[]> {
+  // In a real app this would fetch from a GraphQL endpoint
+  return TALENT_PROFILES;
+}
+
 export function useTalentData() {
-  const [isLoading, setIsLoading] = useState(false);
-  const [talents] = useState<TalentProfile[]>(TALENT_PROFILES);
-  
-  // In a real app, we would fetch data from an API here
-  // For now, we'll just return our mock data
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['talent-profiles'],
+    queryFn: fetchTalentProfiles,
+    initialData: [] as TalentProfile[],
+  }) as {
+    data: TalentProfile[] | undefined;
+    isLoading: boolean;
+    error: unknown;
+  };
 
   return {
-    talents,
-    isLoading
+    talents: data ?? [],
+    isLoading,
+    error,
   };
 }

--- a/src/hooks/useTalentDirectory.ts
+++ b/src/hooks/useTalentDirectory.ts
@@ -14,9 +14,10 @@ export function useTalentDirectory() {
   } = useAuthStatus();
 
   // Fetch talent data
-  const { 
-    talents, 
-    isLoading 
+  const {
+    talents,
+    isLoading,
+    error,
   } = useTalentData();
 
   // Apply filters and sorting
@@ -56,6 +57,7 @@ export function useTalentDirectory() {
     talents,
     filteredTalents,
     isLoading,
+    error,
     
     // Search and filter state
     searchTerm,

--- a/src/pages/TalentDirectory.tsx
+++ b/src/pages/TalentDirectory.tsx
@@ -3,6 +3,8 @@ import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { FilterSidebar } from "@/components/talent/FilterSidebar";
 import { TalentResults } from "@/components/talent/TalentResults";
+import { TalentSkeleton } from "@/components/talent/TalentSkeleton";
+import { ErrorBanner } from "@/components/talent/ErrorBanner";
 import { useTalentDirectory } from "@/hooks/useTalentDirectory";
 import { SORT_OPTIONS } from "@/data/sortOptions";
 import { X } from "lucide-react";
@@ -42,6 +44,7 @@ export default function TalentDirectory() {
     selectedTalent,
     setSelectedTalent,
     expandedSections,
+    error,
     isAuthenticated,
     toggleSkill,
     toggleAvailability,
@@ -72,7 +75,23 @@ export default function TalentDirectory() {
     // Navigate to the talent profile page
     navigate(`/talent/${id}`);
   };
-  
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <TalentSkeleton />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <ErrorBanner msg="Unable to load talent profiles." />
+      </div>
+    );
+  }
+
   return (
     <div className="container mx-auto px-4 py-8">
         <div className="flex flex-col space-y-8">


### PR DESCRIPTION
## Summary
- handle undefined talent data
- show skeleton loader
- display error banner for failed queries
- cast useQuery return to avoid TS2347 build error

## Testing
- `npm run build` *(fails: cannot find type definitions for react)*
- `npm run test` *(fails: vitest not found)*