### PR TITLE
Add cookie consent banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,9 @@
     "tailwind-merge": "^2.2.1",
     "vaul": "^0.9.0",
     "zod": "^3.22.4",
-    "yup": "^1.2.0"
+    "yup": "^1.2.0",
+    "js-cookie": "^3.0.5",
+    "react-cookie-consent": "^8.1.1"
   },
   "devDependencies": {
     "@testing-library/cypress": "^8.0.2",

--- a/pages/privacy-settings.tsx
+++ b/pages/privacy-settings.tsx
@@ -1,0 +1,1 @@
+export { default } from '../src/pages/PrivacySettings';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,9 +5,11 @@ import './App.css';
 import { ThemeProvider } from "./components/ThemeProvider";
 import { useScrollToTop } from "./hooks";
 import { WhitelabelProvider } from "./context/WhitelabelContext";
+import { ConsentProvider } from "./context/ConsentContext";
 import { Toaster } from "./components/ui/toaster";
 import { Toaster as SonnerToaster } from "./components/ui/sonner";
 import PwaInstallButton from "./components/PwaInstallButton";
+import { CookieBanner } from "./components/CookieBanner";
 import {
   AuthRoutes,
   DashboardRoutes,
@@ -50,6 +52,7 @@ import RequestQuotePage from './pages/RequestQuote';
 import WishlistPage from './pages/Wishlist';
 import CartPage from './pages/Cart';
 import Checkout from './pages/Checkout';
+import PrivacySettings from './pages/PrivacySettings';
 
 const baseRoutes = [
   { path: '/', element: <Home /> },
@@ -82,6 +85,7 @@ const baseRoutes = [
   { path: '/wishlist', element: <WishlistPage /> },
   { path: '/cart', element: <CartPage /> },
   { path: '/checkout', element: <Checkout /> },
+  { path: '/privacy-settings', element: <PrivacySettings /> },
 ];
 
 const App = () => {
@@ -91,8 +95,9 @@ const App = () => {
   console.log("App.tsx: Rendering Tree");
   return (
     <WhitelabelProvider>
-      <ThemeProvider defaultTheme="dark">
-        <Suspense fallback={<div className="p-4 text-center">Loading...</div>}>
+      <ConsentProvider>
+        <ThemeProvider defaultTheme="dark">
+          <Suspense fallback={<div className="p-4 text-center">Loading...</div>}>
           <ErrorBoundary>
           <Routes>
             {baseRoutes.map(({ path, element }) => (
@@ -114,8 +119,10 @@ const App = () => {
         </Suspense>
         <Toaster />
         <SonnerToaster position="top-right" />
-        <PwaInstallButton />
-      </ThemeProvider>
+          <CookieBanner />
+          <PwaInstallButton />
+        </ThemeProvider>
+      </ConsentProvider>
     </WhitelabelProvider>
   );
 };

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import CookieConsent from 'react-cookie-consent';
+import { Link } from 'react-router-dom';
+import { useConsent } from '@/context/ConsentContext';
+
+export function CookieBanner() {
+  const { acceptAll, rejectNonEssential } = useConsent();
+
+  return (
+    <CookieConsent
+      location="bottom"
+      cookieName="zion_consent_banner"
+      declineButtonText="Reject Non-Essential"
+      buttonText="Accept All"
+      enableDeclineButton
+      disableStyles
+      containerClasses="fixed bottom-0 left-0 right-0 bg-zinc-900 text-white p-4 flex flex-col md:flex-row items-center justify-between space-y-2 md:space-y-0 z-50"
+      buttonClasses="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded"
+      declineButtonClasses="bg-gray-600 hover:bg-gray-700 text-white px-3 py-1 rounded"
+      onAccept={acceptAll}
+      onDecline={rejectNonEssential}
+    >
+      <span className="mr-2">We use cookies to personalize content and ads.</span>
+      <Link to="/privacy-settings" className="underline text-white">Settings</Link>
+    </CookieConsent>
+  );
+}

--- a/src/context/ConsentContext.tsx
+++ b/src/context/ConsentContext.tsx
@@ -1,0 +1,72 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import Cookies from 'js-cookie';
+
+export type ConsentState = {
+  analytics: boolean;
+  ads: boolean;
+};
+
+interface ConsentContextValue {
+  consent: ConsentState;
+  acceptAll: () => void;
+  rejectNonEssential: () => void;
+  updateConsent: (state: ConsentState) => void;
+}
+
+const defaultState: ConsentState = { analytics: false, ads: false };
+
+const ConsentContext = createContext<ConsentContextValue>({
+  consent: defaultState,
+  acceptAll: () => {},
+  rejectNonEssential: () => {},
+  updateConsent: () => {},
+});
+
+function loadAnalytics() {
+  if (document.getElementById('ga-script')) return;
+  const s = document.createElement('script');
+  s.src = 'https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID';
+  s.async = true;
+  s.id = 'ga-script';
+  document.body.appendChild(s);
+  const inline = document.createElement('script');
+  inline.text = `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','GA_MEASUREMENT_ID');`;
+  document.body.appendChild(inline);
+}
+
+function loadAds() {
+  if (document.getElementById('ads-script')) return;
+  const s = document.createElement('script');
+  s.src = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js';
+  s.async = true;
+  s.id = 'ads-script';
+  document.body.appendChild(s);
+}
+
+export function ConsentProvider({ children }: { children: ReactNode }) {
+  const [consent, setConsent] = useState<ConsentState>(() => {
+    const stored = Cookies.get('consent_preferences');
+    return stored ? (JSON.parse(stored) as ConsentState) : defaultState;
+  });
+
+  useEffect(() => {
+    Cookies.set('consent_preferences', JSON.stringify(consent), { expires: 365 });
+  }, [consent]);
+
+  useEffect(() => {
+    if (consent.analytics) loadAnalytics();
+    if (consent.ads) loadAds();
+  }, [consent]);
+
+  const acceptAll = () => setConsent({ analytics: true, ads: true });
+  const rejectNonEssential = () => setConsent({ analytics: false, ads: false });
+  const updateConsent = (state: ConsentState) => setConsent(state);
+
+  return (
+    <ConsentContext.Provider value={{ consent, acceptAll, rejectNonEssential, updateConsent }}>
+      {children}
+    </ConsentContext.Provider>
+  );
+}
+
+export const useConsent = () => useContext(ConsentContext);

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -8,3 +8,4 @@ export {
 } from './RequestQuoteWizard';
 export { ViewModeProvider, useViewMode } from './ViewModeContext';
 export { CartProvider, useCart } from './CartContext';
+export { ConsentProvider, useConsent } from './ConsentContext';

--- a/src/pages/PrivacySettings.tsx
+++ b/src/pages/PrivacySettings.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { Header } from '@/components/Header';
+import { Footer } from '@/components/Footer';
+import { SEO } from '@/components/SEO';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import { useConsent } from '@/context/ConsentContext';
+
+export default function PrivacySettings() {
+  const { consent, updateConsent } = useConsent();
+  const [analytics, setAnalytics] = useState(consent.analytics);
+  const [ads, setAds] = useState(consent.ads);
+
+  const handleSave = () => {
+    updateConsent({ analytics, ads });
+  };
+
+  return (
+    <>
+      <Header />
+      <SEO title="Privacy Settings" description="Manage your cookie preferences" />
+      <main className="container mx-auto px-4 py-8 space-y-6">
+        <h1 className="text-2xl font-bold">Privacy Settings</h1>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <span>Analytics Cookies</span>
+            <Switch checked={analytics} onCheckedChange={setAnalytics} />
+          </div>
+          <div className="flex items-center justify-between">
+            <span>Advertising Cookies</span>
+            <Switch checked={ads} onCheckedChange={setAds} />
+          </div>
+          <Button onClick={handleSave}>Save Preferences</Button>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add ConsentContext for tracking cookies and loading analytics/ads
- show CookieBanner using `react-cookie-consent`
- provide privacy settings page to let users change choices
- export ConsentProvider and update app routes
- add `js-cookie` and `react-cookie-consent` dependencies

## Testing
- `npm run test` *(fails: vitest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find type definitions)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.