### PR TITLE
Add ElasticSearch suggestion API and component

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "cypress:open": "cypress open",
     "cypress:run": "cypress run --browser chrome",
     "test:accessibility": "vitest run tests/Accessibility.test.tsx",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "es:index": "node scripts/index-elasticsearch.js"
   },
   "dependencies": {
     "@hello-pangea/dnd": "^18.0.1",
@@ -71,6 +72,9 @@
     "vaul": "^0.9.0",
     "zod": "^3.22.4",
     "yup": "^1.2.0"
+  },
+  "optionalDependencies": {
+    "@elastic/elasticsearch": "^8.12.0"
   },
   "devDependencies": {
     "@testing-library/cypress": "^8.0.2",

--- a/pages/api/search/suggest.ts
+++ b/pages/api/search/suggest.ts
@@ -1,0 +1,61 @@
+import { Client } from '@elastic/elasticsearch';
+import { generateSearchSuggestions } from '@/data/marketplaceData';
+
+interface Req { method?: string; query?: { q?: string } }
+interface JsonRes {
+  status: (code: number) => JsonRes;
+  json: (data: any) => void;
+  end: (data?: any) => void;
+  setHeader: (name: string, value: string) => void;
+}
+
+const cloudId = process.env.ELASTIC_CLOUD_ID || '';
+const apiKey = process.env.ELASTIC_API_KEY || '';
+
+function getClient() {
+  if (!cloudId || !apiKey) return null;
+  return new Client({ cloud: { id: cloudId }, auth: { apiKey } });
+}
+
+export default async function handler(req: Req, res: JsonRes) {
+  if (req.method !== 'GET') {
+    res.status(405).end();
+    return;
+  }
+  const q = req.query?.q?.toString() || '';
+  if (!q) {
+    res.status(200).json([]);
+    return;
+  }
+
+  const client = getClient();
+  if (client) {
+    try {
+      const esRes = await client.search({
+        index: 'listings',
+        suggest: {
+          'item-suggest': {
+            prefix: q,
+            completion: { field: 'suggest', size: 5 }
+          }
+        }
+      });
+
+      const options = (esRes.suggest?.['item-suggest']?.[0]?.options || []) as any[];
+      const suggestions = options.map(opt => ({
+        text: opt._source.title,
+        type: opt._source.type
+      }));
+      res.status(200).json(suggestions);
+      return;
+    } catch (err) {
+      console.error('Elasticsearch suggest error:', err);
+    }
+  }
+
+  // Fallback to static suggestions
+  const fallback = generateSearchSuggestions()
+    .filter(s => s.text.toLowerCase().startsWith(q.toLowerCase()))
+    .slice(0, 5);
+  res.status(200).json(fallback);
+}

--- a/scripts/index-elasticsearch.js
+++ b/scripts/index-elasticsearch.js
@@ -1,0 +1,57 @@
+import { Client } from '@elastic/elasticsearch';
+import { NEW_PRODUCTS } from '../src/data/newProductsData.js';
+import { NEW_SERVICES } from '../src/data/newServicesData.js';
+import { MOCK_TALENTS } from '../src/data/mockTalents.js';
+
+const { ELASTIC_CLOUD_ID, ELASTIC_API_KEY } = process.env;
+
+if (!ELASTIC_CLOUD_ID || !ELASTIC_API_KEY) {
+  console.error('Missing ELASTIC_CLOUD_ID or ELASTIC_API_KEY');
+  process.exit(1);
+}
+
+const client = new Client({
+  cloud: { id: ELASTIC_CLOUD_ID },
+  auth: { apiKey: ELASTIC_API_KEY }
+});
+
+async function run() {
+  const docs = [];
+  for (const p of NEW_PRODUCTS) {
+    docs.push({ id: `product-${p.id}`, title: p.title, description: p.description, type: 'product' });
+  }
+  for (const s of NEW_SERVICES) {
+    docs.push({ id: `service-${s.id}`, title: s.title, description: s.description, type: 'service' });
+  }
+  for (const t of MOCK_TALENTS) {
+    docs.push({ id: `talent-${t.id}`, title: t.name, description: t.title, type: 'talent' });
+  }
+
+  await client.indices.create({
+    index: 'listings',
+    mappings: {
+      properties: {
+        title: { type: 'text' },
+        description: { type: 'text' },
+        type: { type: 'keyword' },
+        suggest: { type: 'completion' }
+      }
+    }
+  }, { ignore: [400] });
+
+  const body = docs.flatMap(doc => [
+    { index: { _index: 'listings', _id: doc.id } },
+    { ...doc, suggest: { input: [doc.title] } }
+  ]);
+
+  const resp = await client.bulk({ refresh: true, body });
+  if (resp.errors) {
+    console.error('Some documents failed to index');
+  }
+  console.log(`Indexed ${docs.length} documents`);
+}
+
+run().catch(err => {
+  console.error('Indexing error', err);
+  process.exit(1);
+});

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,83 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Search, X } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { AutocompleteSuggestions } from '@/components/search/AutocompleteSuggestions';
+import { SearchSuggestion } from '@/types/search';
+import { useDebounce } from '@/hooks/useDebounce';
+
+interface SearchBarProps {
+  value: string;
+  onChange: (val: string) => void;
+  onSelectSuggestion?: (val: string) => void;
+  placeholder?: string;
+}
+
+export function SearchBar({ value, onChange, onSelectSuggestion, placeholder = 'Search...' }: SearchBarProps) {
+  const [suggestions, setSuggestions] = useState<SearchSuggestion[]>([]);
+  const [focused, setFocused] = useState(false);
+  const debounced = useDebounce(value, 150);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!debounced) {
+      setSuggestions([]);
+      return;
+    }
+    const controller = new AbortController();
+    fetch(`/api/search/suggest?q=${encodeURIComponent(debounced)}`, { signal: controller.signal })
+      .then(res => res.json())
+      .then(data => setSuggestions(data || []))
+      .catch(() => setSuggestions([]));
+    return () => controller.abort();
+  }, [debounced]);
+
+  useEffect(() => {
+    function outside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setFocused(false);
+      }
+    }
+    document.addEventListener('mousedown', outside);
+    return () => document.removeEventListener('mousedown', outside);
+  }, []);
+
+  const handleSelect = (text: string) => {
+    onChange(text);
+    if (onSelectSuggestion) onSelectSuggestion(text);
+    setFocused(false);
+    inputRef.current?.blur();
+  };
+
+  return (
+    <div className="relative w-full" ref={containerRef}>
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-zion-slate" />
+        <Input
+          ref={inputRef}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onFocus={() => setFocused(true)}
+          placeholder={placeholder}
+          className="pl-10 bg-zion-blue border border-zion-blue-light text-white placeholder:text-zion-slate"
+        />
+        {value && (
+          <button
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-zion-slate hover:text-white"
+            onClick={() => onChange('')}
+            aria-label="Clear search"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+      <AutocompleteSuggestions
+        suggestions={suggestions}
+        searchTerm={value}
+        onSelectSuggestion={handleSelect}
+        visible={focused}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add optional dependency for Elasticsearch client and script to bulk index demo data
- implement `pages/api/search/suggest` API with ES completion suggester and static fallback
- create `SearchBar` component that queries suggestion API with debounce

## Testing
- `npm run test` *(fails: vitest not found)*