### PR TITLE
Add unit conversions and shipping options

### DIFF
--- a/api/shipping-rates.js
+++ b/api/shipping-rates.js
@@ -1,0 +1,46 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    res.setHeader('Allow', 'POST');
+    res.end('Method Not Allowed');
+    return;
+  }
+
+  try {
+    const { fromAddress, toAddress, parcel } = req.body || {};
+    const apiKey = process.env.EASYPOST_API_KEY;
+    if (!apiKey) {
+      res.statusCode = 500;
+      res.json({ error: 'Missing EasyPost API key' });
+      return;
+    }
+    const authHeader =
+      'Basic ' + Buffer.from(`${apiKey}:`).toString('base64');
+    const response = await fetch('https://api.easypost.com/v2/shipments', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: authHeader,
+      },
+      body: JSON.stringify({
+        shipment: {
+          to_address: toAddress,
+          from_address: fromAddress,
+          parcel,
+        },
+      }),
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      res.statusCode = 500;
+      res.json({ error: data.error || 'Failed to fetch rates' });
+      return;
+    }
+    res.statusCode = 200;
+    res.json({ rates: data.rates });
+  } catch (err) {
+    console.error('EasyPost error:', err);
+    res.statusCode = 500;
+    res.json({ error: err.message });
+  }
+}

--- a/src/components/CheckoutShippingOptions.tsx
+++ b/src/components/CheckoutShippingOptions.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useState } from 'react';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+
+interface Address {
+  name: string;
+  address: string;
+  city: string;
+  country: string;
+}
+
+interface ShippingRate {
+  id: string;
+  carrier: string;
+  service: string;
+  rate: string;
+  currency: string;
+  delivery_days?: number | null;
+  tax?: string;
+}
+
+interface Props {
+  toAddress: Address | null;
+  onSelect?: (rate: ShippingRate) => void;
+}
+
+const fromAddress = {
+  name: 'Store',
+  street1: '123 Market St',
+  city: 'San Francisco',
+  state: 'CA',
+  zip: '94103',
+  country: 'US',
+};
+
+const parcel = { weight: 1, length: 10, width: 10, height: 10 };
+
+export function CheckoutShippingOptions({ toAddress, onSelect }: Props) {
+  const [rates, setRates] = useState<ShippingRate[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selected, setSelected] = useState<string>('');
+
+  useEffect(() => {
+    if (
+      !toAddress ||
+      !toAddress.address ||
+      !toAddress.city ||
+      !toAddress.country
+    )
+      return;
+    const fetchRates = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch('/api/shipping-rates', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ fromAddress, toAddress, parcel }),
+        });
+        const data = await res.json();
+        if (res.ok) {
+          setRates(data.rates || []);
+        } else {
+          console.error('Rates error', data);
+        }
+      } catch (err) {
+        console.error('Rates error', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchRates();
+  }, [toAddress]);
+
+  const handleChange = (value: string) => {
+    setSelected(value);
+    const rate = rates.find(r => r.id === value);
+    if (rate && onSelect) onSelect(rate);
+  };
+
+  if (!toAddress) return null;
+
+  return (
+    <div className="my-4">
+      <h2 className="font-semibold mb-2">Shipping Options</h2>
+      {loading && <p>Loading...</p>}
+      {!loading && (
+        <RadioGroup value={selected} onValueChange={handleChange} className="space-y-2">
+          {rates.map(rate => (
+            <label key={rate.id} className="flex items-center gap-2">
+              <RadioGroupItem value={rate.id} />
+              <span>
+                {`${rate.carrier} ${rate.service} - ${rate.rate} ${rate.currency}`}
+                {rate.delivery_days && ` (${rate.delivery_days}d)`}
+              </span>
+              {rate.tax && (
+                <span className="ml-1 text-sm">(+{rate.tax} taxes)</span>
+              )}
+            </label>
+          ))}
+        </RadioGroup>
+      )}
+    </div>
+  );
+}
+
+export type { ShippingRate };

--- a/src/context/UnitContext.tsx
+++ b/src/context/UnitContext.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext, ReactNode } from 'react';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import type { UnitSystem } from '@/utils/unitConversion';
+
+function getDefaultUnit(): UnitSystem {
+  if (typeof navigator !== 'undefined') {
+    const region = navigator.language.split('-')[1];
+    if (region === 'US' || region === 'LR' || region === 'MM') {
+      return 'imperial';
+    }
+  }
+  return 'metric';
+}
+
+interface UnitContextState {
+  unit: UnitSystem;
+  setUnit: (u: UnitSystem) => void;
+  toggleUnit: () => void;
+}
+
+const UnitContext = createContext<UnitContextState>({
+  unit: 'metric',
+  setUnit: () => {},
+  toggleUnit: () => {},
+});
+
+export function UnitProvider({ children }: { children: ReactNode }) {
+  const [unit, setUnit] = useLocalStorage<UnitSystem>('unitSystem', getDefaultUnit());
+  const toggleUnit = () => setUnit(unit === 'metric' ? 'imperial' : 'metric');
+  return (
+    <UnitContext.Provider value={{ unit, setUnit, toggleUnit }}>
+      {children}
+    </UnitContext.Provider>
+  );
+}
+
+export const useUnitSystem = () => useContext(UnitContext);

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -8,3 +8,4 @@ export {
 } from './RequestQuoteWizard';
 export { ViewModeProvider, useViewMode } from './ViewModeContext';
 export { CartProvider, useCart } from './CartContext';
+export { UnitProvider, useUnitSystem } from './UnitContext';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,6 +24,7 @@ import { NotificationProvider } from './context';
 import { AnalyticsProvider } from './context/AnalyticsContext';
 import { ViewModeProvider } from './context/ViewModeContext';
 import { CartProvider } from './context/CartContext';
+import { UnitProvider } from './context/UnitContext';
 import { registerServiceWorker } from './serviceWorkerRegistration';
 
 // Initialize a React Query client with global error handling
@@ -52,11 +53,13 @@ try {
                   <AnalyticsProvider>
                     <LanguageProvider authState={{ isAuthenticated: false, user: null }}>
                       <ViewModeProvider>
-                        <CartProvider>
-                          <AppLayout>
-                            <App />
-                          </AppLayout>
-                        </CartProvider>
+                        <UnitProvider>
+                          <CartProvider>
+                            <AppLayout>
+                              <App />
+                            </AppLayout>
+                          </CartProvider>
+                        </UnitProvider>
                       </ViewModeProvider>
                       <LanguageDetectionPopup />
                     </LanguageProvider>

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input';
 import { safeStorage } from '@/utils/safeStorage';
 import { Button } from '@/components/ui/button';
 import { getStripe } from '@/utils/getStripe';
+import { CheckoutShippingOptions, ShippingRate } from '@/components/CheckoutShippingOptions';
 import {
   Form,
   FormField,
@@ -34,6 +35,7 @@ export default function Checkout() {
   const [searchParams] = useSearchParams();
   const [items, setItems] = useState<CartItem[]>([]);
   const form = useForm<CheckoutForm>({ defaultValues: { name: '', email: '', address: '', city: '', country: '' } });
+  const watchAddr = form.watch(['name', 'address', 'city', 'country']);
 
   useEffect(() => {
     const sku = searchParams.get('sku');
@@ -53,13 +55,15 @@ export default function Checkout() {
   }, [searchParams]);
 
   const subtotal = items.reduce((sum, i) => sum + i.price * i.quantity, 0);
+  const [shippingRate, setShippingRate] = useState<ShippingRate | null>(null);
+  const total = subtotal + (shippingRate ? parseFloat(shippingRate.rate) : 0) + (shippingRate?.tax ? parseFloat(shippingRate.tax) : 0);
 
   const onSubmit = async (data: CheckoutForm) => {
     try {
       const res = await fetch('/api/create-payment-intent', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ amount: subtotal }),
+        body: JSON.stringify({ amount: total }),
       });
       const result = await res.json();
       if (!res.ok) throw new Error(result.error || 'Failed');
@@ -131,10 +135,35 @@ export default function Checkout() {
                 <FormMessage />
               </FormItem>
             )} />
+            <CheckoutShippingOptions
+              toAddress={{
+                name: watchAddr[0],
+                address: watchAddr[1],
+                city: watchAddr[2],
+                country: watchAddr[3],
+              }}
+              onSelect={setShippingRate}
+            />
             <div className="border-t pt-4">
               <div className="flex justify-between font-semibold mb-4">
                 <span>Subtotal</span>
                 <span>${subtotal.toFixed(2)}</span>
+              </div>
+              {shippingRate && (
+                <div className="flex justify-between font-semibold mb-4">
+                  <span>Shipping</span>
+                  <span>{parseFloat(shippingRate.rate).toFixed(2)} {shippingRate.currency}</span>
+                </div>
+              )}
+              {shippingRate?.tax && (
+                <div className="flex justify-between font-semibold mb-4">
+                  <span>Duties &amp; Taxes</span>
+                  <span>{parseFloat(shippingRate.tax).toFixed(2)} {shippingRate.currency}</span>
+                </div>
+              )}
+              <div className="flex justify-between font-semibold mb-4">
+                <span>Total</span>
+                <span>{total.toFixed(2)}</span>
               </div>
               <Button className="w-full" type="submit">
                 Pay with Stripe (test)

--- a/src/pages/EquipmentDetail.tsx
+++ b/src/pages/EquipmentDetail.tsx
@@ -6,10 +6,13 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { AspectRatio } from "@/components/ui/aspect-ratio";
 import { ShoppingCart, Star, Truck, Shield, RotateCcw, Clock } from "lucide-react";
+import { Switch } from '@/components/ui/switch';
 import { toast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { getStripe } from "@/utils/getStripe";
 import { safeStorage } from '@/utils/safeStorage';
+import { useUnitSystem } from '@/context';
+import { formatDimensions, formatWeight } from '@/utils/unitConversion';
 
 interface EquipmentSpecification {
   name: string;
@@ -34,6 +37,10 @@ interface EquipmentDetails {
   features: string[];
   warranty?: string;
   returnPolicy?: string;
+  weightKg?: number;
+  widthCm?: number;
+  heightCm?: number;
+  depthCm?: number;
 }
 
 // Sample data - in a real app this would come from an API
@@ -51,6 +58,10 @@ const SAMPLE_EQUIPMENT: { [key: string]: EquipmentDetails } = {
     reviewCount: 23,
     inStock: true,
     expectedShipping: "3-5 business days",
+    weightKg: 18,
+    widthCm: 44.5,
+    heightCm: 8.9,
+    depthCm: 65,
     specifications: [
       { name: "CPU", value: "Dual Xeon" },
       { name: "Memory", value: "64GB RAM" },
@@ -78,6 +89,10 @@ const SAMPLE_EQUIPMENT: { [key: string]: EquipmentDetails } = {
     reviewCount: 87,
     inStock: true,
     expectedShipping: "3-5 business days",
+    weightKg: 2.1,
+    widthCm: 15,
+    heightCm: 12,
+    depthCm: 10,
     specifications: [
       { name: "Sensor", value: "Full-frame CMOS (36 x 24 mm)" },
       { name: "Resolution", value: "8K (8192 x 4320)" },
@@ -87,7 +102,6 @@ const SAMPLE_EQUIPMENT: { [key: string]: EquipmentDetails } = {
       { name: "Frame Rates", value: "Up to 120fps at 4K, 60fps at 8K" },
       { name: "Storage", value: "Dual CFexpress Type B" },
       { name: "Battery Life", value: "~3 hours continuous recording" },
-      { name: "Weight", value: "4.5 lbs (body only)" },
       { name: "Connectivity", value: "HDMI 2.1, USB-C, Wi-Fi, Bluetooth" }
     ],
     features: [
@@ -122,6 +136,10 @@ const SAMPLE_EQUIPMENT: { [key: string]: EquipmentDetails } = {
     reviewCount: 42,
     inStock: true,
     expectedShipping: "5-7 business days",
+    weightKg: 14.5,
+    widthCm: 55,
+    heightCm: 20,
+    depthCm: 45,
     specifications: [
       { name: "Channels", value: "32 input channels" },
       { name: "Faders", value: "16 motorized faders" },
@@ -130,8 +148,7 @@ const SAMPLE_EQUIPMENT: { [key: string]: EquipmentDetails } = {
       { name: "EQ", value: "4-band parametric per channel" },
       { name: "Dynamics", value: "Compressor/Gate on all channels" },
       { name: "Effects", value: "8 stereo effects processors" },
-      { name: "Recording", value: "64-channel USB interface" },
-      { name: "Weight", value: "32 lbs" }
+      { name: "Recording", value: "64-channel USB interface" }
     ],
     features: [
       "32-channel digital mixer with 24 premium mic preamps",
@@ -156,9 +173,32 @@ export default function EquipmentDetail() {
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
   const [quantity, setQuantity] = useState(1);
   const [isAdding, setIsAdding] = useState(false);
+  const { unit, setUnit } = useUnitSystem();
   
   // In a real app, this would fetch from an API
   const equipment = id ? SAMPLE_EQUIPMENT[id] : undefined;
+
+  const specsToDisplay = equipment
+    ? [
+        ...equipment.specifications,
+        ...(equipment.widthCm && equipment.heightCm && equipment.depthCm
+          ? [
+              {
+                name: 'Dimensions',
+                value: formatDimensions(
+                  equipment.widthCm,
+                  equipment.heightCm,
+                  equipment.depthCm,
+                  unit
+                ),
+              },
+            ]
+          : []),
+        ...(equipment.weightKg
+          ? [{ name: 'Weight', value: formatWeight(equipment.weightKg, unit) }]
+          : []),
+      ]
+    : [];
   
   if (!equipment) {
     return (
@@ -284,9 +324,17 @@ export default function EquipmentDetail() {
                   </TabsContent>
                   
                   <TabsContent value="specifications" className="mt-4">
+                    <div className="flex items-center justify-end mb-2 gap-2">
+                      <span className="text-xs">Metric</span>
+                      <Switch
+                        checked={unit === 'imperial'}
+                        onCheckedChange={(c) => setUnit(c ? 'imperial' : 'metric')}
+                      />
+                      <span className="text-xs">Imperial</span>
+                    </div>
                     <div className="bg-zion-blue-dark border border-zion-blue-light rounded-lg p-6">
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        {equipment.specifications.map((spec, index) => (
+                        {specsToDisplay.map((spec, index) => (
                           <div key={index} className="border-b border-zion-blue-light pb-2 mb-2 last:border-0 last:mb-0 last:pb-0">
                             <div className="flex justify-between">
                               <span className="text-zion-slate-light">{spec.name}</span>

--- a/src/utils/unitConversion.ts
+++ b/src/utils/unitConversion.ts
@@ -1,0 +1,38 @@
+export type UnitSystem = 'metric' | 'imperial';
+
+export function cmToIn(cm: number): number {
+  return cm / 2.54;
+}
+
+export function inToCm(inches: number): number {
+  return inches * 2.54;
+}
+
+export function kgToLbs(kg: number): number {
+  return kg * 2.20462;
+}
+
+export function lbsToKg(lbs: number): number {
+  return lbs / 2.20462;
+}
+
+export function formatDimensions(
+  widthCm: number,
+  heightCm: number,
+  depthCm: number,
+  unit: UnitSystem
+): string {
+  if (unit === 'imperial') {
+    const w = cmToIn(widthCm).toFixed(1);
+    const h = cmToIn(heightCm).toFixed(1);
+    const d = cmToIn(depthCm).toFixed(1);
+    return `${w} x ${h} x ${d} in`;
+  }
+  return `${widthCm} x ${heightCm} x ${depthCm} cm`;
+}
+
+export function formatWeight(weightKg: number, unit: UnitSystem): string {
+  return unit === 'imperial'
+    ? `${kgToLbs(weightKg).toFixed(1)} lb`
+    : `${weightKg} kg`;
+}


### PR DESCRIPTION
## Summary
- provide unit conversion helpers and context
- add EasyPost shipping rates API route and UI component
- display shipping options with duties/taxes in checkout
- toggle metric vs imperial specs in equipment details
- wrap app with UnitProvider
- improve shipping rates API auth and option display

## Testing
- `npm run test` *(fails: vitest not found)*