### PR TITLE
Fix ServicesPage API error handling

### DIFF
--- a/src/pages/ServicesPage.tsx
+++ b/src/pages/ServicesPage.tsx
@@ -8,6 +8,7 @@ import { Link } from "react-router-dom";
 import { Globe } from "lucide-react";
 import { useEffect, useState } from "react";
 import apiClient from "@/services/apiClient";
+import { toast } from "@/hooks/use-toast";
 
 
 function getRandomItem<T>(arr: T[]): T {
@@ -114,8 +115,15 @@ export default function ServicesPage() {
 
   useEffect(() => {
     async function load() {
-      const res = await apiClient.get('/services');
-      setListings(res.data as ProductListing[]);
+      try {
+        // '/services' resolves to '/api/services' via apiClient's baseURL
+        const res = await apiClient.get('/services');
+        setListings(res.data as ProductListing[]);
+      } catch (err) {
+        console.error('Failed to fetch services', err);
+        toast.error('Failed to load services. Showing sample data.');
+        setListings(SERVICES);
+      }
     }
     load();
   }, []);


### PR DESCRIPTION
## Summary
- show toast notifications when the services API fails
- fall back to sample service listings on failure
- document that apiClient.baseURL resolves `/services` to `/api/services`

## Testing
- `npm run test` *(fails: vitest not found)*