### PR TITLE
Preserve checkout context on login

### DIFF
--- a/cypress/e2e/buy_now_login_redirect.cy.ts
+++ b/cypress/e2e/buy_now_login_redirect.cy.ts
@@ -1,0 +1,21 @@
+describe('guest buy now flow', () => {
+  it('redirects through login to checkout', () => {
+    cy.intercept('POST', '/api/auth/login', {
+      statusCode: 200,
+      body: { token: 'jwt', user: { id: '1', email: 'test@example.com' } },
+      headers: { 'set-cookie': 'token=jwt; HttpOnly; Path=/' },
+    }).as('login');
+
+    cy.visit('/equipment/pro-camera-x1000');
+    cy.contains('Buy Now').click();
+    cy.url().should('include', '/login?next=%2Fcheckout%3Fsku%3Dpro-camera-x1000');
+
+    cy.get('input[name="email"]').type('test@example.com');
+    cy.get('input[name="password"]').type('Password123');
+    cy.contains('Login').click();
+    cy.wait('@login');
+
+    cy.url().should('include', '/checkout?sku=pro-camera-x1000');
+    cy.contains('pro-camera-x1000');
+  });
+});

--- a/src/components/transactions/PaymentButton.tsx
+++ b/src/components/transactions/PaymentButton.tsx
@@ -37,10 +37,9 @@ export function PaymentButton({
         title: "Authentication required",
         description: "Please sign in to make a purchase.",
       });
-      
-      navigate("/login", { 
-        state: { from: window.location.pathname } 
-      });
+
+      const next = encodeURIComponent(`/checkout?sku=${serviceId}`);
+      navigate(`/login?next=${next}`);
       return;
     }
     

--- a/src/context/auth/AuthProvider.tsx
+++ b/src/context/auth/AuthProvider.tsx
@@ -61,6 +61,12 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
               // Show welcome toast when user logs in
               if (event === 'SIGNED_IN') {
                 handleSignedIn(mappedUser);
+                const params = new URLSearchParams(location.search);
+                const next = params.get('next');
+                if (next) {
+                  const dest = decodeURIComponent(next);
+                  navigate(dest, { replace: true });
+                }
               }
             } else if (error) {
               console.error("Error fetching user profile:", error);

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { safeStorage } from '@/utils/safeStorage';
 import { Button } from '@/components/ui/button';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { getStripe } from '@/utils/getStripe';
 
 interface CartItem {
@@ -13,9 +13,16 @@ interface CartItem {
 
 export default function Checkout() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [items, setItems] = useState<CartItem[]>([]);
 
   useEffect(() => {
+    const sku = searchParams.get('sku');
+    if (sku) {
+      setItems([{ id: sku, name: sku, price: 25, quantity: 1 }]);
+      return;
+    }
+
     const stored = safeStorage.getItem('cart');
     if (stored) {
       try {
@@ -37,7 +44,7 @@ export default function Checkout() {
         quantity: 1,
       },
     ]);
-  }, []);
+  }, [searchParams]);
 
   const handleCheckout = async () => {
     const product = items[0];

--- a/src/pages/EquipmentDetail.tsx
+++ b/src/pages/EquipmentDetail.tsx
@@ -189,7 +189,8 @@ export default function EquipmentDetail() {
 
   const handleBuyNow = async () => {
     if (!isAuthenticated) {
-      navigate(`/login?next=/equipment/${id}`);
+      const next = encodeURIComponent(`/checkout?sku=${id}`);
+      navigate(`/login?next=${next}`);
       return;
     }
 

--- a/tests/MarketplaceCard.test.tsx
+++ b/tests/MarketplaceCard.test.tsx
@@ -35,7 +35,7 @@ describe('MarketplaceCard Buy Now', () => {
     );
 
     fireEvent.click(screen.getByRole('button'));
-    expect(navigateMock).toHaveBeenCalledWith('/login', { state: { from: '/' } });
+    expect(navigateMock).toHaveBeenCalledWith('/login?next=%2Fcheckout%3Fsku%3D1');
   });
 });
 


### PR DESCRIPTION
## Summary
- redirect unauthenticated Buy Now clicks to `/login` with next param
- after login, AuthProvider decodes and navigates to the next URL
- load `sku` query in checkout page to prefill items
- adjust PaymentButton unit test for new redirect
- add cypress test for guest buy flow
- decode next param before navigation

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run build` *(fails: missing type definitions)*