### PR TITLE
Add more products page

### DIFF
--- a/pages/more-products.tsx
+++ b/pages/more-products.tsx
@@ -1,0 +1,1 @@
+export { default } from '../src/pages/MoreProductsPage';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import Categories from './pages/Categories';
 import Blog from './pages/Blog';
 import BlogPost from './pages/BlogPost';
 import NewProductsPage from './pages/NewProductsPage';
+import MoreProductsPage from './pages/MoreProductsPage';
 import Sitemap from './pages/Sitemap';
 import PartnersPage from './pages/Partners';
 import Login from './pages/Login';
@@ -61,6 +62,7 @@ const baseRoutes = [
   { path: '/equipment', element: <EquipmentPage /> },
   { path: '/equipment/:id', element: <EquipmentDetail /> },
   { path: '/new-products', element: <NewProductsPage /> },
+  { path: '/more-products', element: <MoreProductsPage /> },
   { path: '/analytics', element: <Analytics /> },
   { path: '/mobile-launch', element: <MobileLaunchPage /> },
   { path: '/open-app', element: <OpenAppRedirect /> },

--- a/src/data/moreProductsData.ts
+++ b/src/data/moreProductsData.ts
@@ -1,0 +1,195 @@
+import { ProductListing } from "@/types/listings";
+
+export const MORE_PRODUCTS: ProductListing[] = [
+  {
+    id: "mp-ai-copywriter",
+    title: "AI Copywriter Pro",
+    description: "Generate engaging marketing copy for blogs, ads, and emails.",
+    category: "Content Creation",
+    price: 750,
+    currency: "$",
+    tags: ["Copywriting", "Marketing", "AI"],
+    author: { name: "WriteGen", id: "writegen" },
+    images: [
+      "https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=800&h=500"
+    ],
+    createdAt: "2024-04-11T10:00:00.000Z",
+    rating: 4.5,
+    reviewCount: 20,
+    location: "Global",
+    availability: "Immediate",
+    aiScore: 85
+  },
+  {
+    id: "mp-sales-insights",
+    title: "Sales Insights Dashboard",
+    description: "Track sales metrics with AI-driven forecasting and alerts.",
+    category: "Business Solutions",
+    price: 1650,
+    currency: "$",
+    tags: ["Sales", "Analytics", "Dashboard"],
+    author: { name: "ForecastAI", id: "forecastai" },
+    images: [
+      "https://images.unsplash.com/photo-1556157382-97eda2d62296?auto=format&fit=crop&w=800&h=500"
+    ],
+    createdAt: "2024-04-12T09:30:00.000Z",
+    rating: 4.6,
+    reviewCount: 15,
+    location: "North America",
+    availability: "1-2 Weeks",
+    aiScore: 88
+  },
+  {
+    id: "mp-helpdesk-bot",
+    title: "Helpdesk Chatbot",
+    description: "Automate support tickets with an intelligent chatbot.",
+    category: "Virtual Assistants",
+    price: 900,
+    currency: "$",
+    tags: ["Chatbot", "Support", "Automation"],
+    author: { name: "AssistFlow", id: "assistflow" },
+    images: [
+      "https://images.unsplash.com/photo-1557555187-807fa78b1c7e?auto=format&fit=crop&w=800&h=500"
+    ],
+    createdAt: "2024-04-13T11:15:00.000Z",
+    rating: 4.4,
+    reviewCount: 12,
+    location: "Global",
+    availability: "Immediate",
+    aiScore: 84
+  },
+  {
+    id: "mp-analytics-kit",
+    title: "Starter Analytics Kit",
+    description: "Visualize key metrics with ready-made analytics templates.",
+    category: "Data Analysis",
+    price: 550,
+    currency: "$",
+    tags: ["Analytics", "Visualization", "Templates"],
+    author: { name: "DataFirst", id: "datafirst" },
+    images: [
+      "https://images.unsplash.com/photo-1551288049-bebda4e38f71?auto=format&fit=crop&w=800&h=500"
+    ],
+    createdAt: "2024-04-14T08:45:00.000Z",
+    rating: 4.3,
+    reviewCount: 10,
+    location: "Europe",
+    availability: "Immediate",
+    aiScore: 82
+  },
+  {
+    id: "mp-content-planner",
+    title: "Content Planner AI",
+    description: "Plan and schedule content automatically across channels.",
+    category: "Marketing",
+    price: 700,
+    currency: "$",
+    tags: ["Content", "Scheduler", "Marketing"],
+    author: { name: "PlanAhead", id: "planahead" },
+    images: [
+      "https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=800&h=500"
+    ],
+    createdAt: "2024-04-15T09:10:00.000Z",
+    rating: 4.5,
+    reviewCount: 14,
+    location: "Global",
+    availability: "Immediate",
+    aiScore: 86
+  },
+  {
+    id: "mp-design-studio",
+    title: "AI Design Studio",
+    description: "Create logos and graphics with simple AI-powered tools.",
+    category: "Design",
+    price: 620,
+    currency: "$",
+    tags: ["Design", "Graphics", "AI"],
+    author: { name: "SketchAI", id: "sketchai" },
+    images: [
+      "https://images.unsplash.com/photo-1580894908361-967195033215?auto=format&fit=crop&w=800&h=500"
+    ],
+    createdAt: "2024-04-16T10:05:00.000Z",
+    rating: 4.4,
+    reviewCount: 9,
+    location: "Global",
+    availability: "Immediate",
+    aiScore: 83
+  },
+  {
+    id: "mp-audio-enhancer",
+    title: "Audio Enhancer Suite",
+    description: "Clean and optimize recordings using AI noise reduction.",
+    category: "Voice & Speech",
+    price: 850,
+    currency: "$",
+    tags: ["Audio", "Enhancement", "Noise Reduction"],
+    author: { name: "SoundBoost", id: "soundboost" },
+    images: [
+      "https://images.unsplash.com/photo-1505232070786-2ac7803a5bc9?auto=format&fit=crop&w=800&h=500"
+    ],
+    createdAt: "2024-04-17T12:20:00.000Z",
+    rating: 4.5,
+    reviewCount: 11,
+    location: "Global",
+    availability: "Immediate",
+    aiScore: 85
+  },
+  {
+    id: "mp-project-hub",
+    title: "AI Project Hub",
+    description: "Manage projects with automated task tracking and reports.",
+    category: "Productivity",
+    price: 1300,
+    currency: "$",
+    tags: ["Project Management", "Automation", "Reports"],
+    author: { name: "TaskAI", id: "taskai" },
+    images: [
+      "https://images.unsplash.com/photo-1559027615-ce3b7d81f40a?auto=format&fit=crop&w=800&h=500"
+    ],
+    createdAt: "2024-04-18T14:40:00.000Z",
+    rating: 4.6,
+    reviewCount: 16,
+    location: "Global",
+    availability: "1-2 Weeks",
+    aiScore: 87
+  },
+  {
+    id: "mp-customer-analytics",
+    title: "Customer Analytics Toolkit",
+    description: "Understand customer behavior with prebuilt analytics models.",
+    category: "Data Analysis",
+    price: 1500,
+    currency: "$",
+    tags: ["Customer", "Analytics", "Insights"],
+    author: { name: "InsightHub", id: "insighthub" },
+    images: [
+      "https://images.unsplash.com/photo-1521791136064-7986c2920216?auto=format&fit=crop&w=800&h=500"
+    ],
+    createdAt: "2024-04-19T13:55:00.000Z",
+    rating: 4.5,
+    reviewCount: 13,
+    location: "North America",
+    availability: "2-3 Weeks",
+    aiScore: 88
+  },
+  {
+    id: "mp-smart-crm",
+    title: "Smart CRM Starter",
+    description: "Simplify customer management with AI-assisted workflows.",
+    category: "Business Solutions",
+    price: 1700,
+    currency: "$",
+    tags: ["CRM", "Automation", "Sales"],
+    author: { name: "CRMJet", id: "crmjet" },
+    images: [
+      "https://images.unsplash.com/photo-1518441902114-f0ce5d1fb743?auto=format&fit=crop&w=800&h=500"
+    ],
+    createdAt: "2024-04-20T09:25:00.000Z",
+    rating: 4.6,
+    reviewCount: 18,
+    location: "Global",
+    availability: "Immediate",
+    aiScore: 89
+  }
+];
+

--- a/src/pages/MoreProductsPage.tsx
+++ b/src/pages/MoreProductsPage.tsx
@@ -1,0 +1,24 @@
+import { useState } from "react";
+import { DynamicListingPage } from "@/components/DynamicListingPage";
+import { ProductListing } from "@/types/listings";
+import { MORE_PRODUCTS } from "@/data/moreProductsData";
+
+const CATEGORY_FILTERS = Array.from(
+  new Set(MORE_PRODUCTS.map(p => p.category))
+).map(c => ({ label: c, value: c }));
+
+export default function MoreProductsPage() {
+  const [listings] = useState<ProductListing[]>([...MORE_PRODUCTS]);
+
+  return (
+    <DynamicListingPage
+      title="More Products"
+      description="Browse additional offerings priced for the average market."
+      categorySlug="more-products"
+      listings={listings}
+      categoryFilters={CATEGORY_FILTERS}
+      initialPrice={{ min: 0, max: 2000 }}
+    />
+  );
+}
+

--- a/src/routes/MarketplaceRoutes.tsx
+++ b/src/routes/MarketplaceRoutes.tsx
@@ -21,6 +21,7 @@ import ProjectRoom from "@/pages/ProjectRoom";
 import VideoCall from "@/pages/VideoCall";
 import Checkout from "@/pages/Checkout";
 import NewProductsPage from "@/pages/NewProductsPage";
+import MoreProductsPage from "@/pages/MoreProductsPage";
 
 const MarketplaceRoutes = () => {
   return (
@@ -37,6 +38,7 @@ const MarketplaceRoutes = () => {
       <Route path="/equipment" element={<EquipmentPage />} />
       <Route path="/equipment/:id" element={<EquipmentDetail />} />
       <Route path="/new-products" element={<NewProductsPage />} />
+      <Route path="/more-products" element={<MoreProductsPage />} />
       
       {/* Job Routes */}
       <Route


### PR DESCRIPTION
## Summary
- create data for additional mid-priced products
- add MoreProductsPage using DynamicListingPage
- wire up new route in app and marketplace routes
- expose page in Next.js `pages` directory

## Testing
- `npm run test` *(fails: vitest not found)*