### PR TITLE
Fix talent details page

### DIFF
--- a/pages/talent/[id].tsx
+++ b/pages/talent/[id].tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import type { GetStaticPaths, GetStaticProps } from 'next';
+import type { GetServerSideProps } from 'next';
+import Head from 'next/head';
 import { TALENT_PROFILES } from '@/data/talentData';
 import type { TalentProfile } from '@/types/talent';
 import TalentDetails from '@/components/talent/TalentDetails';
 import NotFound from '@/components/NotFound';
 
 interface TalentPageProps {
-  talent: TalentProfile | null;
+  talent: (TalentProfile & { social?: Record<string, string> }) | null;
 }
 
 const TalentPage: React.FC<TalentPageProps> = ({ talent }) => {
@@ -14,23 +15,36 @@ const TalentPage: React.FC<TalentPageProps> = ({ talent }) => {
     return <NotFound />;
   }
 
-  return <TalentDetails talent={talent} />;
+  return (
+    <>
+      <Head>
+        <title>{talent.full_name}</title>
+      </Head>
+      <TalentDetails talent={talent} />
+    </>
+  );
 };
 
-export const getStaticPaths: GetStaticPaths = async () => {
-  const paths = TALENT_PROFILES.map((t) => ({ params: { id: t.id } }));
-  return { paths, fallback: 'blocking' };
-};
+export const getServerSideProps: GetServerSideProps<TalentPageProps> = async ({ params }) => {
+  const id = params?.id as string | undefined;
 
-export const getStaticProps: GetStaticProps<TalentPageProps> = async ({ params }) => {
-  const id = params?.id as string;
-  const talent = TALENT_PROFILES.find((t) => t.id === id) || null;
-
-  if (!talent) {
+  if (!id) {
     return { notFound: true };
   }
 
-  return { props: { talent } };
+  const profile = TALENT_PROFILES.find((t) => t.id === id) || null;
+
+  if (!profile) {
+    return { notFound: true };
+  }
+
+  const first = profile.full_name.split(' ')[0].toLowerCase();
+  const social = {
+    twitter: `https://twitter.com/${first}`,
+    linkedin: `https://linkedin.com/in/${first}`,
+  };
+
+  return { props: { talent: { ...profile, social } } };
 };
 
 export default TalentPage;

--- a/src/components/talent/TalentDetails.tsx
+++ b/src/components/talent/TalentDetails.tsx
@@ -2,16 +2,46 @@ import React from 'react';
 import { TalentProfile } from '@/types/talent';
 import { Button } from '@/components/ui/button';
 
-interface TalentDetailsProps {
-  talent: TalentProfile;
+export interface TalentDetailsProps {
+  talent: TalentProfile & { social?: Record<string, string> };
 }
-
 const TalentDetails: React.FC<TalentDetailsProps> = ({ talent }) => (
   <main className="min-h-screen bg-zion-blue py-8 text-white" data-testid="talent-details">
     <div className="container mx-auto px-4 space-y-6">
       <h1 className="text-3xl font-bold">{talent.full_name}</h1>
+      {talent.professional_title && <p className="text-zion-slate-light">{talent.professional_title}</p>}
 
       {talent.bio && <p>{talent.bio}</p>}
+
+      {talent.skills && talent.skills.length > 0 && (
+        <section>
+          <h2 className="text-xl font-semibold mb-2">Skills</h2>
+          <ul className="flex flex-wrap gap-2">
+            {talent.skills.map((skill) => (
+              <li key={skill} className="bg-zion-blue-light rounded px-2 py-1 text-sm">
+                {skill}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {talent.hourly_rate && <p>Hourly Rate: ${talent.hourly_rate}/hr</p>}
+
+      {talent.social && (
+        <section>
+          <h2 className="text-xl font-semibold mb-2">Contact</h2>
+          <ul className="space-y-1">
+            {Object.entries(talent.social).map(([platform, url]) => (
+              <li key={platform}>
+                <a href={url} className="text-zion-cyan underline" target="_blank" rel="noopener noreferrer">
+                  {platform}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
       {talent.key_projects && talent.key_projects.length > 0 && (
         <section>


### PR DESCRIPTION
## Summary
- fetch a single talent profile on server-side
- display skills, rate and contact links in TalentDetails

## Testing
- `npm run test` *(fails: vitest not found)*