### PR TITLE
Fix community category listing

### DIFF
--- a/cypress/e2e/community-category.cy.ts
+++ b/cypress/e2e/community-category.cy.ts
@@ -1,0 +1,7 @@
+describe('community category listing', () => {
+  it('displays posts in Getting Hired category', () => {
+    cy.visit('/community');
+    cy.contains('Getting Hired').click();
+    cy.get('[data-testid="post-card"]').its('length').should('be.greaterThan', 0);
+  });
+});

--- a/src/components/community/PostCard.tsx
+++ b/src/components/community/PostCard.tsx
@@ -19,7 +19,7 @@ export const PostCard = ({ post, compact = false }: PostCardProps) => {
   const timeAgo = formatDistanceToNow(new Date(post.createdAt), { addSuffix: true });
 
   return (
-    <Card className={cn(
+    <Card data-testid="post-card" className={cn(
       "transition-shadow hover:shadow-md",
       post.isPinned && "border-zion-purple/50",
       post.isFeatured && "bg-zion-purple/5"

--- a/src/components/community/PostCardSkeleton.tsx
+++ b/src/components/community/PostCardSkeleton.tsx
@@ -1,0 +1,33 @@
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export const PostCardSkeleton = () => (
+  <Card data-testid="post-card-skeleton">
+    <CardHeader className="flex flex-row items-start gap-4 space-y-0">
+      <Skeleton className="h-10 w-10 rounded-full" />
+      <div className="flex-1 space-y-2">
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-3 w-1/4" />
+      </div>
+    </CardHeader>
+    <CardContent>
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+      </div>
+    </CardContent>
+    <CardFooter>
+      <Skeleton className="h-4 w-24" />
+    </CardFooter>
+  </Card>
+);
+
+export const PostListSkeleton = ({ count = 3 }: { count?: number }) => (
+  <div className="space-y-4">
+    {Array.from({ length: count }).map((_, i) => (
+      <PostCardSkeleton key={i} />
+    ))}
+  </div>
+);
+
+export default PostCardSkeleton;

--- a/src/hooks/usePostsByCategory.ts
+++ b/src/hooks/usePostsByCategory.ts
@@ -2,11 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchPostsByCategory } from '@/services/forumPostService';
 import type { ForumPost } from '@/types/community';
 
-export function usePostsByCategory(slug?: string) {
+export function usePostsByCategory(slug?: string, page = 1) {
   return useQuery({
-    queryKey: ['posts', 'category', slug],
+    queryKey: ['posts', 'category', slug, page],
     queryFn: () =>
-      slug ? fetchPostsByCategory(slug) : Promise.resolve([] as ForumPost[]),
+      slug ? fetchPostsByCategory(slug, page) : Promise.resolve([] as ForumPost[]),
     enabled: !!slug,
     suspense: true,
     initialData: [] as ForumPost[],

--- a/src/pages/ForumCategoryPage.tsx
+++ b/src/pages/ForumCategoryPage.tsx
@@ -7,6 +7,7 @@ import CreatePostButton from "@/components/community/CreatePostButton";
 import { Input } from "@/components/ui/input";
 import { SEO } from "@/components/SEO";
 import PostCard from "@/components/community/PostCard";
+import { PostListSkeleton } from "@/components/community/PostCardSkeleton";
 import { ForumCategoryInfo } from "@/types/community";
 import { usePostsByCategory } from "@/hooks/usePostsByCategory";
 import NotFound from "./NotFound";
@@ -84,7 +85,7 @@ function CategoryContent({
     data: posts = [],
     isPending: loading,
     error,
-  } = usePostsByCategory(categoryId);
+  } = usePostsByCategory(categoryId, 1);
   const errorMessage = error instanceof Error ? error.message : null;
 
   const filteredPosts = searchQuery
@@ -135,7 +136,7 @@ function CategoryContent({
       </div>
 
       {loading ? (
-        <div className="text-center py-16">Loading...</div>
+        <PostListSkeleton />
       ) : errorMessage ? (
         <div className="text-center py-16 text-destructive">{errorMessage}</div>
       ) : posts.length > 0 ? (
@@ -176,7 +177,7 @@ export default function ForumCategoryPage() {
         canonical={`https://app.ziontechgroup.com/community/category/${categoryId}`}
       />
 
-      <Suspense fallback={<div className="text-center py-16">Loading...</div>}>
+      <Suspense fallback={<PostListSkeleton />}> 
         <CategoryContent
           categoryId={categoryId}
           category={category}

--- a/src/services/forumPostService.ts
+++ b/src/services/forumPostService.ts
@@ -1,12 +1,19 @@
 import { supabase } from '@/integrations/supabase/client';
 import { ForumPost } from '@/types/community';
 
-export async function fetchPostsByCategory(categoryId: string): Promise<ForumPost[]> {
+export async function fetchPostsByCategory(
+  categoryId: string,
+  page = 1,
+  limit = 20
+): Promise<ForumPost[]> {
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
   const { data, error } = await supabase
     .from('forum_posts')
     .select('*')
     .eq('category_id', categoryId)
-    .order('created_at', { ascending: false });
+    .order('created_at', { ascending: false })
+    .range(from, to);
 
   if (error) {
     throw new Error(error.message);

--- a/tests/usePostsByCategory.test.ts
+++ b/tests/usePostsByCategory.test.ts
@@ -26,7 +26,7 @@ it('returns posts for slug', async () => {
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
 
-  const { result } = renderHook(() => usePostsByCategory('getting-hired'), { wrapper });
+  const { result } = renderHook(() => usePostsByCategory('getting-hired', 1), { wrapper });
 
   await waitFor(() => expect(result.current.data?.length).toBeGreaterThan(0));
 });


### PR DESCRIPTION
## Summary
- paginate community posts query
- add skeleton loader for category list
- show error message if posts can't load
- mark post cards with data-testid
- update hook and tests for pagination
- test clicking Getting Hired category shows posts

## Testing
- `npm run test` *(fails: vitest not found)*