### PR TITLE
Add API-driven TalentDetail page

### DIFF
--- a/src/pages/TalentDetail.jsx
+++ b/src/pages/TalentDetail.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import api from '@/services/apiClient';
+import NotFound from '@/components/NotFound';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
+
+export default function TalentDetail() {
+  const { id } = useParams();
+  const { data, isLoading } = useQuery(['talent', id], async () => {
+    const res = await api.get(`/talent/${id}`);
+    return res.data.profile;
+  }, { enabled: !!id });
+
+  if (isLoading) {
+    return (
+      <div className="p-4 space-y-2" data-testid="talent-loading">
+        <Skeleton className="h-8 w-1/3" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-2/3" />
+      </div>
+    );
+  }
+
+  if (!data) {
+    return <NotFound />;
+  }
+
+  return (
+    <main className="min-h-screen bg-zion-blue py-8 text-white" data-testid="talent-details">
+      <div className="container mx-auto px-4 space-y-4">
+        <h1 className="text-3xl font-bold" data-testid="talent-name">{data.full_name}</h1>
+        {data.bio && <p>{data.bio}</p>}
+        {data.skills && data.skills.length > 0 && (
+          <ul className="list-disc ml-4">
+            {data.skills.map(skill => (
+              <li key={skill}>{skill}</li>
+            ))}
+          </ul>
+        )}
+        {data.average_rating && <p>Rating: {data.average_rating}</p>}
+        <Button className="bg-zion-purple text-white">Contact</Button>
+      </div>
+    </main>
+  );
+}

--- a/src/routes/TalentRoutes.tsx
+++ b/src/routes/TalentRoutes.tsx
@@ -4,7 +4,7 @@ import TalentDirectory from "../pages/TalentDirectory";
 import TalentsPage from "../pages/TalentsPage";
 import MoreTalentsPage from "../pages/MoreTalentsPage";
 import AdditionalTalentsPage from "../pages/AdditionalTalentsPage";
-import TalentProfilePage from "../pages/TalentProfilePage";
+import TalentDetail from "../pages/TalentDetail";
 import SavedTalentsPage from "../pages/SavedTalentsPage";
 import CreateTalentProfile from "../pages/CreateTalentProfile";
 import ProfilePage from "../pages/ProfilePage";
@@ -17,7 +17,7 @@ const TalentRoutes = () => {
       <Route path="/talents" element={<TalentsPage />} />
       <Route path="/more-talents" element={<MoreTalentsPage />} />
       <Route path="/additional-talents" element={<AdditionalTalentsPage />} />
-      <Route path="/talent/:id" element={<TalentProfilePage />} />
+      <Route path="/talent/:id" element={<TalentDetail />} />
       <Route 
         path="/saved-talents" 
         element={

--- a/tests/TalentDetail.test.tsx
+++ b/tests/TalentDetail.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import TalentDetail from '@/pages/TalentDetail';
+
+const server = setupServer(
+  rest.get('/api/talent/t-001', (_req, res, ctx) =>
+    res(ctx.json({
+      profile: {
+        id: 't-001',
+        full_name: 'Test Talent',
+        bio: 'Bio',
+        skills: ['React'],
+        average_rating: 4.5,
+      },
+    }))
+  )
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function renderPage() {
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <MemoryRouter initialEntries={['/talent/t-001']}>
+        <Routes>
+          <Route path="/talent/:id" element={<TalentDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+test('renders profile data from API', async () => {
+  renderPage();
+  expect(await screen.findByTestId('talent-name')).toHaveTextContent('Test Talent');
+});


### PR DESCRIPTION
## Summary
- implement `TalentDetail` page that fetches profile data
- update talent routes to use the new page
- add integration test mocking the API with MSW

## Testing
- `npm run test` *(fails: vitest not found)*