### PR TITLE
Add AI recommendations fetch for equipment

### DIFF
--- a/src/hooks/useRecommendations.ts
+++ b/src/hooks/useRecommendations.ts
@@ -1,0 +1,19 @@
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url).then(res => {
+  if (!res.ok) throw new Error('Failed to fetch recommendations');
+  return res.json();
+});
+
+export function useRecommendations(category: string | undefined, enabled = true) {
+  const key = enabled && category ? `/recommendations?category=${encodeURIComponent(category)}` : null;
+  const { data, error, isValidating } = useSWR<any[]>(key, fetcher, {
+    dedupingInterval: 600000, // 10 minutes
+  });
+
+  return {
+    recommendations: data,
+    error,
+    isLoading: enabled && isValidating && !data,
+  };
+}

--- a/src/pages/EquipmentPage.tsx
+++ b/src/pages/EquipmentPage.tsx
@@ -2,6 +2,10 @@ import { DynamicListingPage } from "@/components/DynamicListingPage";
 import { ProductListing } from "@/types/listings";
 import { useEffect, useState } from "react";
 import { generateRandomEquipment } from "@/utils/generateRandomEquipment";
+import { Button } from "@/components/ui/button";
+import { Loader2, Sparkles } from "lucide-react";
+import { toast } from "@/hooks/use-toast";
+import { useRecommendations } from "@/hooks/useRecommendations";
 
 const API_BASE = '/api';
 
@@ -351,6 +355,16 @@ export default function EquipmentPage() {
   const [listings, setListings] = useState<ProductListing[]>([
     ...EQUIPMENT_LISTINGS,
   ]);
+  const [fetchAI, setFetchAI] = useState(false);
+  const { recommendations, isLoading: recLoading } = useRecommendations('equipment', fetchAI);
+
+  useEffect(() => {
+    if (recommendations) {
+      setListings(recommendations as ProductListing[]);
+      toast({ title: 'Showing AI‑matched results' });
+      setFetchAI(false);
+    }
+  }, [recommendations]);
 
   useEffect(() => {
     async function fetchEquipment() {
@@ -374,7 +388,22 @@ export default function EquipmentPage() {
     return () => clearInterval(interval);
   }, []);
 
+  const handleAIRecommendations = () => setFetchAI(true);
+
   return (
+    <>
+      <div className="bg-zion-blue-dark py-4 px-4 md:px-8 mb-6 border-b border-zion-blue-light">
+        <div className="container mx-auto flex justify-end">
+          <Button onClick={handleAIRecommendations} disabled={recLoading} className="bg-gradient-to-r from-zion-purple to-zion-purple-dark text-white">
+            {recLoading ? (
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            ) : (
+              <Sparkles className="h-4 w-4 mr-2" />
+            )}
+            AI Recommendations
+          </Button>
+        </div>
+      </div>
       <DynamicListingPage
         title="Datacenter Equipment"
         description="Browse professional hardware for modern datacenter and network deployments."
@@ -384,5 +413,6 @@ export default function EquipmentPage() {
         initialPrice={{ min: 400, max: 50000 }}
         detailBasePath="/equipment"
       />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- create `useRecommendations` hook with SWR caching
- pull AI recommended equipment via button in `EquipmentPage`

## Testing
- `npm run test` *(fails: vitest not found)*