### PR TITLE
Fix search suggestions overlay

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { AutocompleteSuggestions } from '@/components/search/AutocompleteSuggestions';
 import { SearchSuggestion } from '@/types/search';
 import { useDebounce } from '@/hooks/useDebounce';
+import { useOnClickOutside } from '@/hooks/useOnClickOutside';
 
 interface SearchBarProps {
   value: string;
@@ -32,15 +33,7 @@ export function SearchBar({ value, onChange, onSelectSuggestion, placeholder = '
     return () => controller.abort();
   }, [debounced]);
 
-  useEffect(() => {
-    function outside(e: MouseEvent) {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setFocused(false);
-      }
-    }
-    document.addEventListener('mousedown', outside);
-    return () => document.removeEventListener('mousedown', outside);
-  }, []);
+  useOnClickOutside(containerRef, () => setFocused(false));
 
   const handleSelect = (text: string) => {
     onChange(text);

--- a/src/components/search/AutocompleteSuggestions.tsx
+++ b/src/components/search/AutocompleteSuggestions.tsx
@@ -39,8 +39,8 @@ export function AutocompleteSuggestions({
   if (!visible || suggestions.length === 0) return null;
   
   return (
-    <div className="absolute z-50 top-full left-0 right-0 mt-1 bg-zion-blue-dark border border-zion-blue-light rounded-lg shadow-lg overflow-hidden">
-      <ul className="py-2 max-h-60 overflow-y-auto">
+    <div className="absolute z-50 top-full left-0 right-0 w-full mt-1 bg-zion-blue-dark border border-zion-blue-light rounded-lg shadow-lg overflow-hidden">
+      <ul className="py-2 max-h-64 overflow-y-auto">
         {suggestions.map((suggestion, index) => {
           const highlight = highlightMatch(suggestion.text, searchTerm);
 

--- a/src/hooks/useOnClickOutside.ts
+++ b/src/hooks/useOnClickOutside.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+export function useOnClickOutside(
+  ref: React.RefObject<HTMLElement>,
+  handler: (e: MouseEvent | TouchEvent) => void
+) {
+  useEffect(() => {
+    function listener(event: MouseEvent | TouchEvent) {
+      const el = ref.current;
+      if (!el || el.contains(event.target as Node)) {
+        return;
+      }
+      handler(event);
+    }
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler]);
+}

--- a/tests/e2e/searchbar.mobile.spec.ts
+++ b/tests/e2e/searchbar.mobile.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test.use({ viewport: { width: 375, height: 667 } });
+
+test('search suggestions close on outside click on mobile', async ({ page }) => {
+  await page.goto('/search');
+
+  const input = page.getByPlaceholder('Search talent, jobs, and projects...');
+  await input.click();
+  await input.type('AI');
+
+  const suggestion = page.getByText('AI models');
+  await expect(suggestion).toBeVisible();
+
+  // click outside the search component
+  await page.click('body', { position: { x: 5, y: 5 } });
+  await expect(suggestion).not.toBeVisible();
+});


### PR DESCRIPTION
## Summary
- keep dropdown within search container
- allow vertical scrolling
- close when clicking outside
- add mobile E2E test for search suggestions

## Testing
- `npm run test` *(fails: vitest not found)*