### PR TITLE
Enable Stripe test mode for preview

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 NEXT_PUBLIC_STRIPE_TEST_KEY=pk_test_your_test_key
 STRIPE_SECRET_KEY=sk_test_your_secret_key
+STRIPE_TEST_SECRET_KEY=sk_test_your_secret_key
 STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
 SERVERLESS_FUNCTION_SECRET=your-serverless-secret
 VITE_STRIPE_PUBLISHABLE_KEY=pk_live_your_publishable_key

--- a/api/create-checkout-session.js
+++ b/api/create-checkout-session.js
@@ -1,5 +1,16 @@
 import Stripe from 'stripe';
 
+const PROD_DOMAIN = 'app.ziontechgroup.com';
+
+function isProdDomain() {
+  const url = process.env.URL || '';
+  try {
+    return new URL(url).hostname === PROD_DOMAIN;
+  } catch {
+    return false;
+  }
+}
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     res.statusCode = 405;
@@ -16,7 +27,14 @@ export default async function handler(req, res) {
   }
 
   try {
-    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+    const liveKey = process.env.STRIPE_SECRET_KEY || '';
+    const testKey = process.env.STRIPE_TEST_SECRET_KEY || liveKey;
+
+    if (!isProdDomain() && liveKey.startsWith('sk_live') && !process.env.STRIPE_TEST_SECRET_KEY) {
+      throw new Error('Refusing to use live Stripe key on non-production domain');
+    }
+
+    const stripe = new Stripe(isProdDomain() ? liveKey : testKey, {
       apiVersion: '2023-10-16',
     });
 

--- a/api/create-payment-intent.js
+++ b/api/create-payment-intent.js
@@ -1,5 +1,16 @@
 import Stripe from 'stripe';
 
+const PROD_DOMAIN = 'app.ziontechgroup.com';
+
+function isProdDomain() {
+  const url = process.env.URL || '';
+  try {
+    return new URL(url).hostname === PROD_DOMAIN;
+  } catch {
+    return false;
+  }
+}
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     res.statusCode = 405;
@@ -16,7 +27,14 @@ export default async function handler(req, res) {
   }
 
   try {
-    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+    const liveKey = process.env.STRIPE_SECRET_KEY || '';
+    const testKey = process.env.STRIPE_TEST_SECRET_KEY || liveKey;
+
+    if (!isProdDomain() && liveKey.startsWith('sk_live') && !process.env.STRIPE_TEST_SECRET_KEY) {
+      throw new Error('Refusing to use live Stripe key on non-production domain');
+    }
+
+    const stripe = new Stripe(isProdDomain() ? liveKey : testKey, {
       apiVersion: '2023-10-16',
     });
     const intent = await stripe.paymentIntents.create({

--- a/cypress/e2e/checkout_payment.cy.ts
+++ b/cypress/e2e/checkout_payment.cy.ts
@@ -1,0 +1,45 @@
+describe('test checkout purchase', () => {
+  it('completes a $0.50 test purchase', () => {
+    cy.loginByApi('existing@test.com', 'password123');
+
+    const intentId = 'pi_test_123';
+    cy.intercept('POST', '/api/create-payment-intent', {
+      statusCode: 200,
+      body: { clientSecret: 'cs_test_secret', id: intentId },
+    }).as('createIntent');
+    cy.intercept('POST', '/api/points/add', { statusCode: 200 }).as('addPoints');
+    cy.intercept('GET', /\/api\/orders\/.*/, (req) => {
+      const id = req.url.split('/').pop();
+      req.reply({
+        statusCode: 200,
+        body: {
+          orderId: id,
+          date: '2024-05-01',
+          total: '$0.50',
+          status: 'paid',
+          invoiceUrl: '/inv.pdf',
+          items: [{ name: 'Test', price: 0.5, quantity: 1 }],
+          shippingAddress: { name: 'QA Tester', street: '123', city: 'Test', state: 'TS', zip: '12345' },
+          trackingEvents: [],
+        },
+      });
+    }).as('getOrder');
+
+    cy.visit('/checkout?sku=test-sku');
+    cy.get('input[name="name"]').type('QA Tester');
+    cy.get('input[name="email"]').type('qa@example.com');
+    cy.get('input[name="address"]').type('123 Test St');
+    cy.get('input[name="city"]').type('Testville');
+    cy.get('input[name="country"]').type('Testland');
+
+    cy.contains('Pay with Stripe').click();
+
+    cy.wait('@createIntent');
+    cy.wait('@addPoints');
+    cy.wait('@getOrder');
+
+    cy.url().should('include', '/orders/');
+    cy.contains('Order #').should('be.visible');
+  });
+});
+

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -4,8 +4,9 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Input } from '@/components/ui/input';
 import { safeStorage } from '@/utils/safeStorage';
 import { Button } from '@/components/ui/button';
-import { getStripe } from '@/utils/getStripe';
+import { getStripe, isProdDomain } from '@/utils/getStripe';
 import { PointsBadge } from '@/components/loyalty/PointsBadge';
+import { Badge } from '@/components/ui/badge';
 import { useAuth } from '@/hooks/useAuth';
 import {
   Form,
@@ -37,6 +38,7 @@ export default function Checkout() {
   const [items, setItems] = useState<CartItem[]>([]);
   const form = useForm<CheckoutForm>({ defaultValues: { name: '', email: '', address: '', city: '', country: '' } });
   const { user } = useAuth();
+  const testMode = !isProdDomain();
 
   useEffect(() => {
     const sku = searchParams.get('sku');
@@ -96,6 +98,12 @@ export default function Checkout() {
 
   return (
     <div className="container max-w-2xl py-10">
+      {testMode && (
+        <div className="mb-4 flex items-center gap-2">
+          <Badge variant="warning">Test Mode</Badge>
+          <span className="text-sm">Use test card <code className="font-mono">4242 4242 4242 4242</code></span>
+        </div>
+      )}
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-3xl font-bold">Checkout</h1>
         <PointsBadge />
@@ -154,7 +162,7 @@ export default function Checkout() {
                 <span>${subtotal.toFixed(2)}</span>
               </div>
               <Button className="w-full" type="submit">
-                Pay with Stripe (test)
+                Pay with Stripe{testMode ? ' (test)' : ''}
               </Button>
             </div>
           </form>

--- a/src/utils/getStripe.ts
+++ b/src/utils/getStripe.ts
@@ -1,13 +1,35 @@
 import { loadStripe, Stripe } from '@stripe/stripe-js';
 
+export const PROD_DOMAIN = 'app.ziontechgroup.com';
+
+export function isProdDomain(host?: string) {
+  if (typeof window === 'undefined') {
+    const url = host || process.env.URL;
+    if (!url) return false;
+    try {
+      return new URL(url).hostname === PROD_DOMAIN;
+    } catch {
+      return false;
+    }
+  }
+  return (host || window.location.hostname) === PROD_DOMAIN;
+}
+
 let stripePromise: Promise<Stripe | null>;
 
 export function getStripe() {
   if (!stripePromise) {
-    const key =
-      process.env.NODE_ENV === 'production'
-        ? (import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY as string)
-        : (import.meta.env.NEXT_PUBLIC_STRIPE_TEST_KEY as string);
+    const testKey = import.meta.env.NEXT_PUBLIC_STRIPE_TEST_KEY as string;
+    let key = testKey;
+
+    const prodKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY as string | undefined;
+    if (prodKey && isProdDomain()) {
+      key = prodKey;
+    } else if (prodKey && !isProdDomain()) {
+      // warn if someone tried to inject a live key outside prod
+      console.warn('Ignoring production Stripe key on non-production domain');
+    }
+
     stripePromise = loadStripe(key);
   }
   return stripePromise;


### PR DESCRIPTION
## Summary
- prevent loading live Stripe keys on preview domains
- expose `STRIPE_TEST_SECRET_KEY`
- show **Test Mode** badge and sample card numbers on Checkout page
- allow backend payment handlers to switch based on domain
- cover checkout success flow with Cypress

## Testing
- `./setup.sh npm` *(fails: getStripe dependencies need network)*
- `npm run test` *(fails: vitest not found)*