### PR TITLE
Fix request quote wizard API fetch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ STRIPE_SECRET_KEY=sk_test_your_secret_key
 STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
 SERVERLESS_FUNCTION_SECRET=your-serverless-secret
 VITE_STRIPE_PUBLISHABLE_KEY=pk_live_your_publishable_key
+VITE_API_URL=https://backend.example.com

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/api/*"
+  to = "https://backend.example.com/:splat"
+  status = 200

--- a/src/api/services.ts
+++ b/src/api/services.ts
@@ -1,0 +1,25 @@
+const BASE_URL = import.meta.env.VITE_API_URL || '/api';
+
+export interface ServiceItem {
+  id: string;
+  title: string;
+  category?: string;
+  price?: number;
+  rating?: number;
+  image?: string;
+}
+
+export async function fetchServices(category?: string, q?: string): Promise<ServiceItem[]> {
+  const params = new URLSearchParams();
+  if (category) params.append('category', category);
+  if (q) params.append('q', q);
+  const url = `${BASE_URL}/services?${params.toString()}`;
+  const res = await fetch(url, {
+    mode: 'cors',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to fetch services');
+  }
+  return res.json();
+}

--- a/src/components/QuoteRequestForm/ServiceTypeStep.tsx
+++ b/src/components/QuoteRequestForm/ServiceTypeStep.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { QuoteFormData, ListingItem, ServiceType } from "@/types/quotes";
 import { Input } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
@@ -7,6 +7,8 @@ import { ListingScoreCard } from "@/components/ListingScoreCard";
 import { SAMPLE_SERVICES } from "@/data/sampleServices";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDebounce } from "@/hooks/useDebounce";
+import { useQuery } from "@tanstack/react-query";
+import { fetchServices } from "@/api/services";
 
 interface ServiceTypeStepProps {
   formData: QuoteFormData;
@@ -17,54 +19,23 @@ interface ServiceTypeStepProps {
 export function ServiceTypeStep({ formData, updateFormData }: ServiceTypeStepProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const debouncedQuery = useDebounce(searchQuery, 300);
-  const [listings, setListings] = useState<ListingItem[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const {
+    data: listings = [],
+    isPending: loading,
+    error,
+  } = useQuery({
+    queryKey: ['services', formData.serviceType, debouncedQuery],
+    queryFn: () =>
+      fetchServices(formData.serviceType, debouncedQuery),
+    enabled: !!formData.serviceType,
+    retry: 2,
+  });
 
-  // Fetch services when the service type or query changes
-  useEffect(() => {
-    if (!formData.serviceType) {
-      setListings([]);
-      return;
-    }
-
-    const fetchServices = async () => {
-      setLoading(true);
-      setError(null);
-      const url = `/api/services?category=${encodeURIComponent(formData.serviceType)}&q=${encodeURIComponent(debouncedQuery)}`;
-      const maxRetries = 3;
-
-      for (let attempt = 0; attempt < maxRetries; attempt++) {
-        try {
-          const response = await fetch(url);
-          if (!response.ok) throw new Error('Failed to fetch');
-          const data = await response.json();
-          setListings(data as ListingItem[]);
-          setError(null);
-          setLoading(false);
-          return;
-        } catch (err) {
-          if (attempt === maxRetries - 1) {
-            setError('Failed to load services');
-            setListings(
-              SAMPLE_SERVICES.filter(
-                item =>
-                  item.category === formData.serviceType &&
-                  item.title.toLowerCase().includes(debouncedQuery.toLowerCase())
-              )
-            );
-            setLoading(false);
-          } else {
-            await new Promise(res =>
-              setTimeout(res, Math.pow(2, attempt) * 500)
-            );
-          }
-        }
-      }
-    };
-
-    fetchServices();
-  }, [formData.serviceType, debouncedQuery]);
+  const fallbackListings = SAMPLE_SERVICES.filter(
+    (item) =>
+      item.category === formData.serviceType &&
+      item.title.toLowerCase().includes(debouncedQuery.toLowerCase())
+  );
   
   const handleTypeSelect = (type: ServiceType) => {
     updateFormData({ serviceType: type });
@@ -78,7 +49,7 @@ export function ServiceTypeStep({ formData, updateFormData }: ServiceTypeStepPro
     });
   };
   
-  const sourceListings = listings.length > 0 ? listings : SAMPLE_SERVICES;
+  const sourceListings = error ? fallbackListings : listings.length > 0 ? listings : SAMPLE_SERVICES;
 
   const filteredListings = sourceListings.filter(item => {
     // Filter by category only when a service type has been selected
@@ -150,7 +121,9 @@ export function ServiceTypeStep({ formData, updateFormData }: ServiceTypeStepPro
           </div>
 
           {error && (
-            <div className="text-center text-red-400 text-sm">{error}. Showing sample data.</div>
+            <div className="text-center text-red-400 text-sm">
+              {(error as Error).message || 'Failed to load services'}. Showing sample data.
+            </div>
           )}
           
           <div className="grid grid-cols-1 gap-4 mt-4">


### PR DESCRIPTION
## Summary
- add services API helper with base URL and CORS
- fetch services in ServiceTypeStep with React Query retry logic
- refactor QuoteWizard to use React Query
- cast useQuery result to fix type error
- add Netlify proxy for API
- document VITE_API_URL in env example

## Testing
- `npm run test` *(fails: vitest not found)*