### PR TITLE
Fix quote wizard rendering with error boundary

### DIFF
--- a/pages/request-quote.tsx
+++ b/pages/request-quote.tsx
@@ -1,1 +1,0 @@
-export { default } from '../src/pages/RequestQuote';

--- a/pages/request-quote/index.tsx
+++ b/pages/request-quote/index.tsx
@@ -1,0 +1,10 @@
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { QuoteWizard } from "@/components/quote/QuoteWizard";
+
+export default function RequestQuotePage() {
+  return (
+    <ErrorBoundary fallback={<div>Quote wizard failed to load</div>}>
+      <QuoteWizard />
+    </ErrorBoundary>
+  );
+}

--- a/pages/talent/[id].tsx
+++ b/pages/talent/[id].tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
+import type { NextRouter } from 'next/router';
 import { Loader2 } from 'lucide-react';
 import { TALENT_PROFILES } from '@/data/talentData';
 import type { TalentProfile } from '@/types/talent';
@@ -13,9 +14,9 @@ interface TalentPageProps {
 }
 
 const TalentPage: React.FC<TalentPageProps> = ({ talent }) => {
-  const router = useRouter();
+  const router = useRouter() as NextRouter & { isFallback?: boolean };
 
-  if (router.isFallback) {
+  if ('isFallback' in router && router.isFallback) {
     return (
       <div className="flex justify-center py-20">
         <Loader2 className="h-8 w-8 animate-spin text-zion-purple" />

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import { Component, ReactNode, ErrorInfo } from 'react';
 
 interface Props {
   children: ReactNode;
+  fallback?: ReactNode;
 }
 
 interface State {
@@ -35,6 +36,7 @@ export class ErrorBoundary extends Component<Props, State> {
   render() {
     console.log("ErrorBoundary.tsx: Render");
     if (this.state.hasError) {
+      if (this.props.fallback) return <>{this.props.fallback}</>;
       return <div className="p-4 text-center">Something went wrong.</div>;
     }
     return this.props.children;

--- a/tests/RequestQuotePage.test.tsx
+++ b/tests/RequestQuotePage.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import RequestQuotePage from '@/pages/request-quote';
+
+beforeEach(() => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => [{ id: '1', title: 'Service A' }],
+  }) as any;
+});
+
+test('renders quote wizard without runtime errors', async () => {
+  render(
+    <MemoryRouter>
+      <RequestQuotePage />
+    </MemoryRouter>
+  );
+
+  expect(await screen.findByTestId('step-indicator')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add RequestQuote page with QuoteWizard
- extend ErrorBoundary to accept a fallback prop
- wrap QuoteWizard in ErrorBoundary with custom message
- add unit test for RequestQuote page
- handle optional isFallback when rendering Talent page

## Testing
- `npm run test` *(fails: vitest not found)*