### PR TITLE
Improve marketplace grid layout

### DIFF
--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -234,7 +234,11 @@ export default function Marketplace() {
               </div>
             ) : filteredListings.length > 0 ? (
               <div
-                className={view === 'grid' ? 'grid grid-cols-3 gap-6' : 'flex flex-col gap-4'}
+                className={
+                  view === 'grid'
+                    ? 'grid grid-cols-1 sm:grid-cols-2 gap-6'
+                    : 'flex flex-col gap-4'
+                }
                 data-testid="product-container"
               >
                 {paginatedListings.map(listing => (

--- a/tests/MarketplaceViewToggle.test.tsx
+++ b/tests/MarketplaceViewToggle.test.tsx
@@ -50,5 +50,5 @@ test('toggling view updates container class', () => {
   fireEvent.click(listIcon);
   expect(container.className).toContain('flex-col');
   fireEvent.click(gridIcon);
-  expect(container.className).toContain('grid-cols-3');
+  expect(container.className).toContain('grid-cols-2');
 });


### PR DESCRIPTION
## Summary
- update Marketplace grid to display two items per row
- adjust MarketplaceViewToggle test to expect the new layout

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a249d698c832b96071b42fa5ef9ec