### PR TITLE
Add greeting for logged in users

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -25,6 +25,8 @@ export interface HeaderProps {
 
 export function Header({ hideLogin = false, customLogo, customTheme }: HeaderProps) {
   const { user } = useAuth();
+  const firstName =
+    user?.displayName?.split(' ')[0] || user?.name?.split(' ')[0];
   const { isWhitelabel, primaryColor } = useWhitelabel();
   const navigate = useNavigate();
   const [query, setQuery] = useState("");
@@ -78,6 +80,14 @@ export function Header({ hideLogin = false, customLogo, customTheme }: HeaderPro
         <div className="flex items-center gap-2">
           <PointsBadge />
           <LanguageSelector />
+          {user && (
+            <span
+              className="hidden sm:block text-sm text-white mr-2"
+              data-testid="header-greeting"
+            >
+              {`Hello, ${firstName}!`}
+            </span>
+          )}
           {!hideLogin && <UserMenu />}
         </div>
       </div>

--- a/src/layout/AppHeader.tsx
+++ b/src/layout/AppHeader.tsx
@@ -10,11 +10,15 @@ import { MobileMenu } from '@/components/header/MobileMenu';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { MobileBottomNav } from '@/components/header/MobileBottomNav';
 import { PointsBadge } from '@/components/loyalty/PointsBadge';
+import { useAuth } from '@/hooks/useAuth';
 
 export function AppHeader() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const isMobile = useIsMobile();
   const { t } = useTranslation();
+  const { user } = useAuth();
+  const firstName =
+    user?.displayName?.split(' ')[0] || user?.name?.split(' ')[0];
   
   // Try to access the messaging context, but provide a fallback value if it's not available
   let unreadCount = 0;
@@ -53,6 +57,14 @@ export function AppHeader() {
 
           <PointsBadge />
           <LanguageSelector />
+          {user && (
+            <span
+              className="hidden sm:block ml-4 text-sm text-white"
+              data-testid="header-greeting"
+            >
+              {`Hello, ${firstName}!`}
+            </span>
+          )}
         </div>
       </header>
       

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { useAuth } from "@/hooks/useAuth";
 import { CategoriesSection } from "@/components/CategoriesSection";
 import { BenefitsSection } from "@/components/BenefitsSection";
 import { HowItWorksSection } from "@/components/HowItWorksSection";
@@ -13,14 +14,26 @@ import { FeatureHighlights } from "@/components/home/FeatureHighlights";
 import { ITServiceRequestHero } from "@/components/home/ITServiceRequestHero";
 
 export default function Home() {
+  const { user } = useAuth();
+  const firstName =
+    user?.displayName?.split(' ')[0] || user?.name?.split(' ')[0];
   return (
     <div className="min-h-screen bg-background">
-      <SEO 
-        title="Zion - The Tech & AI Marketplace" 
+      <SEO
+        title="Zion - The Tech & AI Marketplace"
         description="Discover top AI and tech talent, services, and equipment in one place."
         keywords="AI, technology, marketplace, services, talent"
         canonical="https://app.ziontechgroup.com/"
       />
+
+      {user && (
+        <div
+          className="bg-zion-blue-light text-white text-center p-2"
+          data-testid="home-greeting"
+        >
+          {`Hello, ${firstName}!`}
+        </div>
+      )}
 
       <ITServiceRequestHero />
 


### PR DESCRIPTION
## Summary
- greet logged in user in `AppHeader`
- show greeting in main `Header` component
- display greeting on homepage top section

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a242b5e04832ba245f7219cb63e1c