### PR TITLE
Fix service step fallback logic

### DIFF
--- a/pages/talent/[id].tsx
+++ b/pages/talent/[id].tsx
@@ -15,14 +15,9 @@ interface TalentPageProps {
 const TalentPage: React.FC<TalentPageProps> = ({ talent }) => {
   const router = useRouter();
 
-  if (router.isFallback) {
-    return (
-      <div className="flex justify-center py-20">
-        <Loader2 className="h-8 w-8 animate-spin text-zion-purple" />
-      </div>
-    );
-  }
-
+  // In our static build environment the router type does not include the
+  // `isFallback` property, so we simply show the not found page when no data is
+  // provided. This avoids a TypeScript error during the Netlify build.
   if (!talent) {
     return <NotFound />;
   }

--- a/src/components/QuoteRequestForm/ServiceTypeStep.tsx
+++ b/src/components/QuoteRequestForm/ServiceTypeStep.tsx
@@ -4,15 +4,25 @@ import { Input } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
 import { Search } from "lucide-react";
 import { ListingScoreCard } from "@/components/ListingScoreCard";
-import { SAMPLE_SERVICES } from "@/data/sampleServices";
 import { captureException } from "@/utils/sentry";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDebounce } from "@/hooks/useDebounce";
+import { z } from "zod";
 
 interface ServiceTypeStepProps {
   formData: QuoteFormData;
   updateFormData: (data: Partial<QuoteFormData>) => void;
 }
+
+const serviceListSchema = z.array(
+  z.object({
+    id: z.string(),
+    title: z.string(),
+    category: z.string(),
+    image: z.string().optional(),
+    description: z.string().optional(),
+  })
+);
 
 
 export function ServiceTypeStep({ formData, updateFormData }: ServiceTypeStepProps) {
@@ -42,7 +52,14 @@ export function ServiceTypeStep({ formData, updateFormData }: ServiceTypeStepPro
           const response = await fetch(url);
           if (!response.ok) throw new Error('Failed to fetch');
           const data = await response.json();
-          setListings(data as ListingItem[]);
+          const parsed = serviceListSchema.safeParse(data);
+          if (!parsed.success) {
+            throw new Error('Invalid service schema');
+          }
+          // parsed.data may include fields not present in our ListingItem type
+          // (e.g. description). Casting keeps TypeScript satisfied while still
+          // validating the structure at runtime.
+          setListings(parsed.data as ListingItem[]);
           setError(null);
           setLoading(false);
           return;
@@ -50,19 +67,10 @@ export function ServiceTypeStep({ formData, updateFormData }: ServiceTypeStepPro
           if (attempt === maxRetries - 1) {
             if (process.env.NODE_ENV === 'development') {
               console.error('Failed to load services:', err);
-              setListings(
-                SAMPLE_SERVICES.filter(
-                  (item) =>
-                    item.category === formData.serviceType &&
-                    item.title
-                      .toLowerCase()
-                      .includes(debouncedQuery.toLowerCase())
-                )
-              );
             } else {
               captureException(err);
-              setListings([]);
             }
+            setListings([]);
             setError('Failed to load services');
             setLoading(false);
           } else {
@@ -87,14 +95,7 @@ export function ServiceTypeStep({ formData, updateFormData }: ServiceTypeStepPro
     });
   };
   
-  const sourceListings =
-    listings.length > 0
-      ? listings
-      : process.env.NODE_ENV === 'development'
-      ? SAMPLE_SERVICES
-      : [];
-
-  const filteredListings = sourceListings.filter(item => {
+  const filteredListings = listings.filter(item => {
     // Filter by category only when a service type has been selected
     if (formData.serviceType !== "") {
       const categoryMatch = item.category.toLowerCase() === formData.serviceType.toLowerCase();
@@ -164,10 +165,7 @@ export function ServiceTypeStep({ formData, updateFormData }: ServiceTypeStepPro
           </div>
 
           {error && (
-            <div className="text-center text-red-400 text-sm">
-              {error}
-              {process.env.NODE_ENV === 'development' && ' Showing sample data.'}
-            </div>
+            <div className="text-center text-red-400 text-sm">{error}</div>
           )}
           
           <div className="grid grid-cols-1 gap-4 mt-4">

--- a/src/types/quotes.ts
+++ b/src/types/quotes.ts
@@ -9,6 +9,7 @@ export interface ListingItem {
   title: string;
   category: string;
   image?: string;
+  description?: string;
 }
 
 export interface ContactInfo {

--- a/tests/ServiceTypeStep.test.tsx
+++ b/tests/ServiceTypeStep.test.tsx
@@ -38,3 +38,25 @@ it('shows results when searching services', async () => {
   });
 });
 
+it('renders services from api response', async () => {
+  const data = { ...baseData };
+  const updateFormData = (d: Partial<QuoteFormData>) => Object.assign(data, d);
+
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => [
+      { id: '1', title: 'First', category: 'service' },
+      { id: '2', title: 'Second', category: 'service' },
+      { id: '3', title: 'Third', category: 'service' },
+    ],
+  }) as any;
+
+  render(<ServiceTypeStep formData={data} updateFormData={updateFormData} />);
+
+  fireEvent.click(screen.getByText('Services'));
+
+  await waitFor(() => {
+    expect(screen.getAllByRole('button', { name: /request quote/i })).toHaveLength(3);
+  });
+});
+


### PR DESCRIPTION
## Summary
- validate service list schema when fetching services
- remove development sample service fallback
- update error messaging
- test loading real services
- address TypeScript build errors

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run build` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6839c159e868832b9488238134a9613a