### PR TITLE
Fix Vite allowed hosts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
   server: {
     hmr: {
       clientPort: 443
-    }
+    },
+    allowedHosts: ['devserver-preview--ziontechgroup.netlify.app']
   }
 })


### PR DESCRIPTION
## Summary
- permit Netlify preview URL in Vite config

## Testing
- `npm run test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683a56ac3520832b8f893fb240ba7f27