### PR TITLE
Fix talent profile crash

### DIFF
--- a/pages/talent/[id].tsx
+++ b/pages/talent/[id].tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import type { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -6,14 +6,19 @@ import { Loader2 } from 'lucide-react';
 import { TALENT_PROFILES } from '@/data/talentData';
 import type { TalentProfile } from '@/types/talent';
 import TalentDetails from '@/components/talent/TalentDetails';
-import NotFound from '@/components/NotFound';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 
 interface TalentPageProps {
   talent: (TalentProfile & { social?: Record<string, string> }) | null;
 }
 
 const TalentPage: React.FC<TalentPageProps> = ({ talent }) => {
-  const router = useRouter();
+  const router = useRouter() as any;
+  useEffect(() => {
+    if (!talent) {
+      console.log('TalentPage: talent prop is undefined');
+    }
+  }, [talent]);
 
   if (router.isFallback) {
     return (
@@ -24,7 +29,7 @@ const TalentPage: React.FC<TalentPageProps> = ({ talent }) => {
   }
 
   if (!talent) {
-    return <NotFound />;
+    return <div className="p-4 text-center">Talent not found or unavailable</div>;
   }
 
   return (
@@ -32,7 +37,9 @@ const TalentPage: React.FC<TalentPageProps> = ({ talent }) => {
       <Head>
         <title>{talent.full_name}</title>
       </Head>
-      <TalentDetails talent={talent} />
+      <ErrorBoundary>
+        <TalentDetails talent={talent} />
+      </ErrorBoundary>
     </>
   );
 };

--- a/tests/TalentDirectoryNavigation.test.tsx
+++ b/tests/TalentDirectoryNavigation.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import TalentDirectory from '@/pages/TalentDirectory';
+import TalentDetail from '@/pages/TalentDetail';
+
+function renderWithRouter() {
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <MemoryRouter initialEntries={['/talent']}>
+        <Routes>
+          <Route path="/talent" element={<TalentDirectory />} />
+          <Route path="/talent/:id" element={<TalentDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+test('opens first talent profile from directory', async () => {
+  renderWithRouter();
+  const firstCard = await screen.findByText('Alexandra Chen');
+  fireEvent.click(firstCard);
+  expect(await screen.findByTestId('talent-details')).toHaveTextContent('Alexandra Chen');
+});


### PR DESCRIPTION
## Summary
- guard `pages/talent/[id].tsx` against missing profile and cast router to avoid TypeScript error
- show fallback UI and wrap talent details in `ErrorBoundary`
- test navigating from directory to profile page

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6839c183e158832b98a33b436d397aaf