### PR TITLE
Add forum empty state

### DIFF
--- a/cypress/e2e/community-empty.cy.ts
+++ b/cypress/e2e/community-empty.cy.ts
@@ -1,0 +1,17 @@
+describe('community empty category', () => {
+  it('shows empty state with disabled CTA', () => {
+    cy.intercept('GET', '**/forum_posts*category_id=eq.announcements*', {
+      statusCode: 200,
+      body: [],
+    }).as('getPosts');
+
+    cy.visit('/community/announcements');
+    cy.wait('@getPosts');
+
+    cy.contains('No discussions yet');
+    cy.contains('Be the first to start a conversation.');
+    cy.contains('Create Post').should('be.disabled');
+    cy.contains('Create Post').trigger('mouseover');
+    cy.contains('Login required');
+  });
+});

--- a/pages/community/[slug].tsx
+++ b/pages/community/[slug].tsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import { MessageSquare } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import EmptyState from '@/components/community/EmptyState';
 import { createClient } from '@supabase/supabase-js';
 import PostCard from '@/components/community/PostCard';
 import type { ForumPost } from '@/types/community';
@@ -27,20 +28,13 @@ const CategoryPage: React.FC<CategoryPageProps> = ({ posts, hasSession, category
             ))}
           </div>
         ) : (
-          <div className="text-center py-16">
-            <div className="bg-zion-blue/30 p-6 rounded-full mb-6 inline-flex">
-              <MessageSquare className="h-10 w-10 text-zion-purple" />
-            </div>
-            <h2 className="text-xl font-medium mb-2">No posts yet</h2>
-            <p className="text-muted-foreground mb-6">Be the first to post</p>
-            {hasSession ? (
-              <Button asChild>
-                <Link href={`/community/create?category=${category}`}>Create New Post</Link>
-              </Button>
-            ) : (
-              <Button disabled>Create New Post</Button>
-            )}
-          </div>
+          <EmptyState
+            title="No discussions yet"
+            subtitle="Be the first to start a conversation."
+            cta="Create Post"
+            href={`/community/create?category=${category}`}
+            hasSession={hasSession}
+          />
         )}
       </main>
     </>

--- a/src/components/community/EmptyState.tsx
+++ b/src/components/community/EmptyState.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import Link from 'next/link';
+import { MessageSquare } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+
+interface EmptyStateProps {
+  title: string;
+  subtitle: string;
+  cta: string;
+  href: string;
+  hasSession: boolean;
+}
+
+const EmptyState: React.FC<EmptyStateProps> = ({ title, subtitle, cta, href, hasSession }) => {
+  return (
+    <div className="text-center py-16">
+      <div className="bg-zion-blue/30 p-6 rounded-full mb-6 inline-flex">
+        <MessageSquare className="h-10 w-10 text-zion-purple" />
+      </div>
+      <h2 className="text-xl font-medium mb-2">{title}</h2>
+      <p className="text-muted-foreground mb-6">{subtitle}</p>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            {hasSession ? (
+              <Button asChild>
+                <Link href={href}>{cta}</Link>
+              </Button>
+            ) : (
+              <Button disabled>{cta}</Button>
+            )}
+          </TooltipTrigger>
+          {!hasSession && <TooltipContent>Login required</TooltipContent>}
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+};
+
+export default EmptyState;

--- a/src/types/external-modules.d.ts
+++ b/src/types/external-modules.d.ts
@@ -349,6 +349,7 @@ declare module 'next/link' {
 declare module 'next/router' {
   interface NextRouter {
     pathname: string
+    isFallback?: boolean
   }
   export function useRouter(): NextRouter
 }


### PR DESCRIPTION
## Summary
- create EmptyState component for community categories
- display EmptyState when no discussions
- add Cypress test for an empty category
- extend NextRouter type to include `isFallback`

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6839c17ed14c832b8bbbef77ede0fa53