### PR TITLE
Fix service step data load

### DIFF
--- a/pages/talent/[id].tsx
+++ b/pages/talent/[id].tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
+import type { NextRouter } from 'next/router';
 import { Loader2 } from 'lucide-react';
 import { TALENT_PROFILES } from '@/data/talentData';
 import type { TalentProfile } from '@/types/talent';
@@ -13,7 +14,7 @@ interface TalentPageProps {
 }
 
 const TalentPage: React.FC<TalentPageProps> = ({ talent }) => {
-  const router = useRouter();
+  const router = useRouter() as NextRouter & { isFallback?: boolean };
 
   if (router.isFallback) {
     return (

--- a/src/components/QuoteRequestForm/ServiceTypeStep.tsx
+++ b/src/components/QuoteRequestForm/ServiceTypeStep.tsx
@@ -4,10 +4,19 @@ import { Input } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
 import { Search } from "lucide-react";
 import { ListingScoreCard } from "@/components/ListingScoreCard";
-import { SAMPLE_SERVICES } from "@/data/sampleServices";
 import { captureException } from "@/utils/sentry";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDebounce } from "@/hooks/useDebounce";
+import { z } from "zod";
+
+const listingSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  category: z.string(),
+  image: z.string().optional(),
+});
+
+const listingsSchema = z.array(listingSchema);
 
 interface ServiceTypeStepProps {
   formData: QuoteFormData;
@@ -42,7 +51,9 @@ export function ServiceTypeStep({ formData, updateFormData }: ServiceTypeStepPro
           const response = await fetch(url);
           if (!response.ok) throw new Error('Failed to fetch');
           const data = await response.json();
-          setListings(data as ListingItem[]);
+          const parsed = listingsSchema.safeParse(data);
+          if (!parsed.success) throw new Error('Invalid response');
+          setListings(parsed.data as ListingItem[]);
           setError(null);
           setLoading(false);
           return;
@@ -50,19 +61,10 @@ export function ServiceTypeStep({ formData, updateFormData }: ServiceTypeStepPro
           if (attempt === maxRetries - 1) {
             if (process.env.NODE_ENV === 'development') {
               console.error('Failed to load services:', err);
-              setListings(
-                SAMPLE_SERVICES.filter(
-                  (item) =>
-                    item.category === formData.serviceType &&
-                    item.title
-                      .toLowerCase()
-                      .includes(debouncedQuery.toLowerCase())
-                )
-              );
             } else {
               captureException(err);
-              setListings([]);
             }
+            setListings([]);
             setError('Failed to load services');
             setLoading(false);
           } else {
@@ -87,12 +89,7 @@ export function ServiceTypeStep({ formData, updateFormData }: ServiceTypeStepPro
     });
   };
   
-  const sourceListings =
-    listings.length > 0
-      ? listings
-      : process.env.NODE_ENV === 'development'
-      ? SAMPLE_SERVICES
-      : [];
+  const sourceListings = listings;
 
   const filteredListings = sourceListings.filter(item => {
     // Filter by category only when a service type has been selected
@@ -164,10 +161,7 @@ export function ServiceTypeStep({ formData, updateFormData }: ServiceTypeStepPro
           </div>
 
           {error && (
-            <div className="text-center text-red-400 text-sm">
-              {error}
-              {process.env.NODE_ENV === 'development' && ' Showing sample data.'}
-            </div>
+            <div className="text-center text-red-400 text-sm">{error}</div>
           )}
           
           <div className="grid grid-cols-1 gap-4 mt-4">

--- a/tests/ServiceTypeStep.test.tsx
+++ b/tests/ServiceTypeStep.test.tsx
@@ -38,3 +38,25 @@ it('shows results when searching services', async () => {
   });
 });
 
+it('renders results from api', async () => {
+  const data = { ...baseData };
+  const updateFormData = (d: Partial<QuoteFormData>) => Object.assign(data, d);
+
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => [
+      { id: 's1', title: 'A', category: 'service' },
+      { id: 's2', title: 'B', category: 'service' },
+      { id: 's3', title: 'C', category: 'service' },
+    ],
+  }) as any;
+
+  render(<ServiceTypeStep formData={data} updateFormData={updateFormData} />);
+
+  fireEvent.click(screen.getByText('Services'));
+
+  await waitFor(() => {
+    expect(screen.getAllByRole('button', { name: /request quote/i })).toHaveLength(3);
+  });
+});
+


### PR DESCRIPTION
## Summary
- validate QuoteRequestForm ServiceTypeStep response with zod
- remove sample service data fallback
- add test to ensure API results render
- fix type errors in talent page and service step

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'react')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6839c022dc68832ba1beb8e9268ee0d0