### PR TITLE
Implement talent detail profile component

### DIFF
--- a/cypress/e2e/talent-detail.cy.ts
+++ b/cypress/e2e/talent-detail.cy.ts
@@ -1,0 +1,19 @@
+describe('talent detail page', () => {
+  it('displays profile info from api', () => {
+    cy.intercept('GET', '/api/talent/t-001', {
+      statusCode: 200,
+      body: {
+        profile: {
+          id: 't-001',
+          full_name: 'Cypress Talent',
+          bio: 'Testing bio',
+          skills: ['React']
+        }
+      }
+    }).as('getTalent');
+
+    cy.visit('/talent/t-001');
+    cy.wait('@getTalent');
+    cy.get('[data-testid="talent-name"]').should('contain', 'Cypress Talent');
+  });
+});

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Loader2 } from 'lucide-react';
+
+export default function Spinner() {
+  return (
+    <div className="flex justify-center py-8" data-testid="spinner">
+      <Loader2 className="h-8 w-8 animate-spin text-zion-purple" />
+    </div>
+  );
+}

--- a/src/components/talent/TalentProfile.tsx
+++ b/src/components/talent/TalentProfile.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+
+export interface TalentProfileProps {
+  id: string;
+  full_name: string;
+  bio?: string;
+  skills?: string[];
+  profile_picture_url?: string;
+}
+
+export default function TalentProfile({
+  full_name,
+  bio,
+  skills = [],
+  profile_picture_url,
+}: TalentProfileProps) {
+  return (
+    <main className="min-h-screen bg-zion-blue py-8 text-white" data-testid="talent-details">
+      <div className="container mx-auto px-4 flex flex-col items-center space-y-4">
+        <Avatar className="h-24 w-24">
+          {profile_picture_url ? (
+            <AvatarImage src={profile_picture_url} alt={full_name} />
+          ) : (
+            <AvatarFallback>{full_name.charAt(0)}</AvatarFallback>
+          )}
+        </Avatar>
+        <h1 className="text-3xl font-bold" data-testid="talent-name">{full_name}</h1>
+        {bio && <p className="text-center max-w-xl">{bio}</p>}
+        {skills.length > 0 && (
+          <ul className="flex flex-wrap justify-center gap-2">
+            {skills.map((skill) => (
+              <li key={skill} className="bg-zion-blue-light rounded px-2 py-1 text-sm">
+                {skill}
+              </li>
+            ))}
+          </ul>
+        )}
+        <Button className="bg-zion-purple text-white" data-testid="contact-button">
+          Contact
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/TalentDetail.jsx
+++ b/src/pages/TalentDetail.jsx
@@ -3,45 +3,19 @@ import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import api from '@/services/apiClient';
 import NotFound from '@/components/NotFound';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Button } from '@/components/ui/button';
+import Spinner from '@/components/Spinner';
+import TalentProfile from '@/components/talent/TalentProfile';
 
 export default function TalentDetail() {
   const { id } = useParams();
-  const { data, isLoading } = useQuery(['talent', id], async () => {
-    const res = await api.get(`/talent/${id}`);
-    return res.data.profile;
-  }, { enabled: !!id });
-
-  if (isLoading) {
-    return (
-      <div className="p-4 space-y-2" data-testid="talent-loading">
-        <Skeleton className="h-8 w-1/3" />
-        <Skeleton className="h-4 w-full" />
-        <Skeleton className="h-4 w-2/3" />
-      </div>
-    );
-  }
-
-  if (!data) {
-    return <NotFound />;
-  }
-
-  return (
-    <main className="min-h-screen bg-zion-blue py-8 text-white" data-testid="talent-details">
-      <div className="container mx-auto px-4 space-y-4">
-        <h1 className="text-3xl font-bold" data-testid="talent-name">{data.full_name}</h1>
-        {data.bio && <p>{data.bio}</p>}
-        {data.skills && data.skills.length > 0 && (
-          <ul className="list-disc ml-4">
-            {data.skills.map(skill => (
-              <li key={skill}>{skill}</li>
-            ))}
-          </ul>
-        )}
-        {data.average_rating && <p>Rating: {data.average_rating}</p>}
-        <Button className="bg-zion-purple text-white">Contact</Button>
-      </div>
-    </main>
+  const { data, isLoading } = useQuery(
+    ['talent', id],
+    () => api.get(`/talent/${id}`).then((r) => r.data.profile),
+    { enabled: !!id }
   );
+
+  if (isLoading) return <Spinner />;
+  if (!data) return <NotFound />;
+
+  return <TalentProfile {...data} />;
 }


### PR DESCRIPTION
## Summary
- load talent data with React Query
- show new `TalentProfile` component with avatar and contact button
- add `Spinner` loading indicator
- create Cypress test for talent detail route

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6839bf613c8c832baace51bfc3c84edf