### PR TITLE
Fix request quote wizard API fetch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ STRIPE_SECRET_KEY=sk_test_your_secret_key
 STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
 SERVERLESS_FUNCTION_SECRET=your-serverless-secret
 VITE_STRIPE_PUBLISHABLE_KEY=pk_live_your_publishable_key
+VITE_API_URL=https://backend.example.com

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ Automatic translations rely on OpenAI. Set `VITE_OPENAI_API_KEY` (or
 `NEXT_PUBLIC_OPENAI_API_KEY`) to allow the client to contact the API directly
 when the Supabase function is unavailable.
 
+### Backend API
+
+Configure `VITE_API_URL` to point to your backend service. The frontend uses this
+value when fetching data such as available services. On Netlify, the
+`netlify.toml` file proxies `/api/*` to this backend.
+
 ## Testing
 
 Run unit tests with:

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/api/*"
+  to = "https://backend.example.com/:splat"
+  status = 200

--- a/src/api/services.ts
+++ b/src/api/services.ts
@@ -1,0 +1,25 @@
+const BASE_URL = import.meta.env.VITE_API_URL || '/api';
+
+export interface ServiceItem {
+  id: string;
+  title: string;
+  category?: string;
+  price?: number;
+  rating?: number;
+  image?: string;
+}
+
+export async function fetchServices(category?: string, q?: string): Promise<ServiceItem[]> {
+  const params = new URLSearchParams();
+  if (category) params.append('category', category);
+  if (q) params.append('q', q);
+  const url = `${BASE_URL}/services?${params.toString()}`;
+  const res = await fetch(url, {
+    mode: 'cors',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to fetch services');
+  }
+  return res.json();
+}

--- a/src/components/quote/QuoteWizard.tsx
+++ b/src/components/quote/QuoteWizard.tsx
@@ -1,23 +1,14 @@
 import { useState } from 'react';
 import type { WizardStep } from '@/context/RequestQuoteWizard';
-import useSWR from 'swr';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useRequestQuoteWizard } from '@/context';
-
-interface ServiceItem {
-  id: string;
-  title: string;
-}
+import { fetchServices, ServiceItem } from '@/api/services';
 
 const WIZARD_STEPS: WizardStep[] = ['Services', 'Details', 'Success'];
-
-const fetcher = (url: string) => fetch(url).then(res => {
-  if (!res.ok) throw new Error('Failed');
-  return res.json();
-});
 
 function StepIndicator({ step }: { step: WizardStep }) {
   const index = WIZARD_STEPS.indexOf(step);
@@ -32,16 +23,18 @@ export function QuoteWizard() {
   const { step, selectService, submitQuote } = useRequestQuoteWizard();
   const [selectedItem, setSelectedItem] = useState<string | null>(null);
   const [message, setMessage] = useState('');
-  const { data, error } = useSWR<ServiceItem[]>('/api/services', fetcher, {
-    onErrorRetry: (error, key, config, revalidate, { retryCount }) => {
-      if (retryCount >= 5) return;
-      const timeout = Math.min(1000 * 2 ** retryCount, 30000);
-      setTimeout(() => revalidate({ retryCount: retryCount + 1 }), timeout);
-    },
-  });
+  const {
+    data = [],
+    isPending,
+    error,
+  } = useQuery({
+    queryKey: ['services'],
+    queryFn: () => fetchServices(),
+    retry: 2,
+  }) as UseQueryResult<ServiceItem[]>;
 
   if (step === 'Services') {
-    const loading = !data && !error;
+    const loading = isPending;
 
     return (
       <div className="space-y-6">


### PR DESCRIPTION
## Summary
- add services API helper with base URL and CORS
- fetch services in ServiceTypeStep with React Query retry logic
- refactor QuoteWizard to use React Query
- add Netlify proxy for API
- document VITE_API_URL in env example and README

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68399e4fbd04832bbf642e3579251a0d