### PR TITLE
Add global error boundary and toast stubs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,8 @@ export default {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@/pages/(.*)$': '<rootDir>/src/pages/$1',
     '^vitest$': '<rootDir>/tests/vitest-mock.ts',
+    '^notistack$': '<rootDir>/src/stubs/notistack.tsx',
+    '^@sentry/browser$': '<rootDir>/src/stubs/sentry.ts',
   },
   roots: ['<rootDir>/__tests__', '<rootDir>/tests'],
   coverageThreshold: {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,9 @@
     "vaul": "^0.9.0",
     "zod": "^3.22.4",
     "yup": "^1.2.0",
-    "firebase": "^9.23.0"
+    "firebase": "^9.23.0",
+    "notistack": "^2.0.11",
+    "@sentry/browser": "^7.91.0"
   },
   "optionalDependencies": {
     "@elastic/elasticsearch": "^8.12.0"

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -63,5 +63,9 @@
     "ar": "العربية",
     "language_changed": "تم تغيير اللغة إلى {{language}}",
     "switch_to_detected": "التبديل إلى {{language}}؟"
+  },
+  "error_boundary": {
+    "message": "حدث خطأ ما.",
+    "retry": "إعادة المحاولة"
   }
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -107,5 +107,9 @@
     "edit": "Edit",
     "saved": "Saved",
     "changes_saved": "Translation changes have been saved"
+  },
+  "error_boundary": {
+    "message": "Something went wrong.",
+    "retry": "Retry"
   }
 }

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -63,5 +63,9 @@
     "ar": "العربية",
     "language_changed": "Idioma cambiado a {{language}}",
     "switch_to_detected": "¿Cambiar a {{language}}?"
+  },
+  "error_boundary": {
+    "message": "Algo salió mal.",
+    "retry": "Reintentar"
   }
 }

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -63,5 +63,9 @@
     "ar": "العربية",
     "language_changed": "Idioma alterado para {{language}}",
     "switch_to_detected": "Mudar para {{language}}?"
+  },
+  "error_boundary": {
+    "message": "Algo deu errado.",
+    "retry": "Tentar novamente"
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,11 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { showApiError } from '@/utils/apiErrorHandler';
 import './utils/globalFetchInterceptor';
+import { ErrorBoundary } from 'react-error-boundary';
+import { SnackbarProvider } from 'notistack';
+import { captureException } from '@/utils/sentry';
+import { useTranslation } from 'react-i18next';
+import { ToastInitializer } from '@/hooks/use-toast';
 
 // Import i18n configuration
 import './i18n';
@@ -39,6 +44,21 @@ const queryClient = new QueryClient({
   },
 });
 
+function GlobalErrorFallback({ error, resetErrorBoundary }: { error: Error; resetErrorBoundary: () => void }) {
+  const { t } = useTranslation();
+  React.useEffect(() => {
+    captureException(error);
+  }, [error]);
+  return (
+    <div role="alert" className="p-4 text-center">
+      <p className="mb-2">{t('error_boundary.message', 'Something went wrong.')}</p>
+      <button className="rounded bg-blue-600 px-4 py-2 text-white" onClick={resetErrorBoundary}>
+        {t('error_boundary.retry', 'Retry')}
+      </button>
+    </div>
+  );
+}
+
 try {
   console.log("main.tsx: Before ReactDOM.createRoot");
   // Render the app with proper provider structure
@@ -46,28 +66,33 @@ try {
     <React.StrictMode>
       <HelmetProvider>
         <QueryClientProvider client={queryClient}>
+          <SnackbarProvider maxSnack={3}>
+            <ToastInitializer />
           <WhitelabelProvider>
             <Router>
               <AuthProvider>
                 <NotificationProvider>
                   <AnalyticsProvider>
                     <LanguageProvider authState={{ isAuthenticated: false, user: null }}>
-                      <ViewModeProvider>
-                        <CartProvider>
-                          <ReferralMiddleware>
-                            <AppLayout>
-                              <App />
-                            </AppLayout>
-                          </ReferralMiddleware>
-                        </CartProvider>
-                      </ViewModeProvider>
-                      <LanguageDetectionPopup />
+                      <ErrorBoundary FallbackComponent={GlobalErrorFallback}>
+                        <ViewModeProvider>
+                          <CartProvider>
+                            <ReferralMiddleware>
+                              <AppLayout>
+                                <App />
+                              </AppLayout>
+                            </ReferralMiddleware>
+                          </CartProvider>
+                        </ViewModeProvider>
+                        <LanguageDetectionPopup />
+                      </ErrorBoundary>
                     </LanguageProvider>
                   </AnalyticsProvider>
                 </NotificationProvider>
               </AuthProvider>
             </Router>
           </WhitelabelProvider>
+          </SnackbarProvider>
         </QueryClientProvider>
       </HelmetProvider>
     </React.StrictMode>,

--- a/src/stubs/notistack.tsx
+++ b/src/stubs/notistack.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+export const SnackbarProvider: React.FC<any> = ({ children }) => <>{children}</>;
+export const useSnackbar = () => {
+  return { enqueueSnackbar: (msg: string) => console.log('snackbar', msg) };
+};
+export type VariantType = 'default' | 'error' | 'success' | 'info' | 'warning';
+export interface OptionsObject { variant?: VariantType; }

--- a/src/stubs/sentry.ts
+++ b/src/stubs/sentry.ts
@@ -1,0 +1,4 @@
+export function init(_opts: any) {}
+export function captureException(error: unknown) {
+  console.error('Sentry stub capture:', error);
+}

--- a/src/types/external-modules.d.ts
+++ b/src/types/external-modules.d.ts
@@ -332,6 +332,8 @@ declare module 'react-dom/client';
 declare module 'react-dom';
 declare module '@hello-pangea/dnd';
 declare module 'react-redux';
+declare module 'notistack';
+declare module '@sentry/browser';
 declare module 'semver';
 declare module 'ws';
 declare module 'recharts';

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -1,4 +1,15 @@
+import * as Sentry from '@sentry/browser';
+
+const DSN = import.meta.env.VITE_SENTRY_DSN;
+
+if (DSN) {
+  Sentry.init({ dsn: DSN });
+}
+
 export function captureException(error: unknown) {
+  if (DSN) {
+    Sentry.captureException(error);
+  }
   if (typeof console !== 'undefined') {
     console.error('Sentry captured exception:', error);
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,9 @@
     "paths": {
       "@/*": ["./src/*"],
       "@/pages/*": ["./src/pages/*"],
-      "axios": ["./src/lib/axios.ts"]
+      "axios": ["./src/lib/axios.ts"],
+      "notistack": ["./src/stubs/notistack.tsx"],
+      "@sentry/browser": ["./src/stubs/sentry.ts"]
     },
     "types": ["vite/client", "react", "react-router-dom", "socket.io", "socket.io-client"],
 


### PR DESCRIPTION
## Summary
- wrap application in `react-error-boundary`
- show fallback with retry button and log via Sentry
- provide notistack-based toast hooks and initializer
- stub Sentry and notistack implementations
- localize error messages
- update config to map stubs for tests
- fix notistack stub extension and update mappings

## Testing
- `npm run build` *(fails: missing type definitions)*
- `npm run test` *(fails: vitest not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6839930d333c832b90fd2bcd00202614