### PR TITLE
Fix buy now auth guard

### DIFF
--- a/src/pages/EquipmentDetail.tsx
+++ b/src/pages/EquipmentDetail.tsx
@@ -8,7 +8,6 @@ import { AspectRatio } from "@/components/ui/aspect-ratio";
 import { ShoppingCart, Star, Truck, Shield, RotateCcw, Clock } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
-import { getStripe } from "@/utils/getStripe";
 import { safeStorage } from '@/utils/safeStorage';
 
 interface EquipmentSpecification {
@@ -197,22 +196,20 @@ export default function EquipmentDetail() {
 
   const handleBuyNow = async () => {
     if (!isAuthenticated) {
-      const next = encodeURIComponent(`/checkout?sku=${id}`);
-      navigate(`/login?next=${next}`);
+      navigate(`/login?next=/product/${id}`);
       return;
     }
 
     setIsAdding(true);
     try {
-      const response = await fetch('/api/checkout_sessions', {
+      const response = await fetch('/checkout/create-session', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ productId: id }),
       });
-      const { sessionId } = await response.json();
-      const stripe = await getStripe();
-      if (stripe && sessionId) {
-        await stripe.redirectToCheckout({ sessionId });
+      const { url } = await response.json();
+      if (url) {
+        window.location.assign(url as string);
       }
     } catch (err) {
       toast({ title: 'Payment error', description: 'Could not start checkout.' });

--- a/tests/EquipmentDetail.test.tsx
+++ b/tests/EquipmentDetail.test.tsx
@@ -26,6 +26,36 @@ describe('EquipmentDetail page', () => {
     expect(container.querySelectorAll('.navbar')).toHaveLength(1);
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it('redirects to Stripe when authenticated', async () => {
+    (router.useParams as jest.Mock).mockReturnValue({ id: 'pro-camera-x1000' });
+
+    const fetchMock = jest
+      .spyOn(global, 'fetch' as any)
+      .mockResolvedValue({
+        json: () => Promise.resolve({ url: 'https://stripe.test/session' })
+      } as any);
+
+    const assignMock = jest.fn();
+    delete (window as any).location;
+    (window as any).location = { assign: assignMock, href: '' };
+
+    const { getByText } = render(
+      <MemoryRouter>
+        <AppLayout>
+          <EquipmentDetail />
+        </AppLayout>
+      </MemoryRouter>
+    );
+
+    getByText('Buy Now').click();
+
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledWith('/checkout/create-session', expect.any(Object));
+    expect(assignMock).toHaveBeenCalledWith('https://stripe.test/session');
+
+    fetchMock.mockRestore();
+  });
 });
 
 


### PR DESCRIPTION
## Summary
- buy now: use auth context and assign stripe url
- redirect guests to login with product url
- test: authenticated user reaches Stripe session

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683992a21100832ba03c1e70a22411d3