### PR TITLE
Fix ServicesPage error handling

### DIFF
--- a/src/pages/ServicesPage.tsx
+++ b/src/pages/ServicesPage.tsx
@@ -1,14 +1,17 @@
-
 import { DynamicListingPage } from "@/components/DynamicListingPage";
 import { ProductListing } from "@/types/listings";
 import { SERVICES } from "@/data/servicesData";
 import { TrustedBySection } from "@/components/TrustedBySection";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
 import { Globe } from "lucide-react";
 import { useEffect, useState } from "react";
+import useSWR from "swr";
 import apiClient from "@/services/apiClient";
-
+import { captureException } from "@/utils/sentry";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "@/hooks/use-toast";
 
 function getRandomItem<T>(arr: T[]): T {
   return arr[Math.floor(Math.random() * arr.length)];
@@ -101,63 +104,96 @@ function generateRandomService(idNum: number): ProductListing {
 
 // Filter options specific to services
 const SERVICE_FILTERS = [
-  { label: 'Development', value: 'development' },
-  { label: 'Management', value: 'management' },
-  { label: 'Security', value: 'security' },
-  { label: 'Analytics', value: 'analytics' },
-  { label: 'Consulting', value: 'consulting' },
-  { label: 'Strategy', value: 'strategy' },
+  { label: "Development", value: "development" },
+  { label: "Management", value: "management" },
+  { label: "Security", value: "security" },
+  { label: "Analytics", value: "analytics" },
+  { label: "Consulting", value: "consulting" },
+  { label: "Strategy", value: "strategy" },
 ];
+
+async function fetchServices() {
+  try {
+    // apiClient resolves "/services" to "/api/services"
+    const res = await apiClient.get("/services");
+    return res.data as ProductListing[];
+  } catch (err) {
+    captureException(err);
+    throw err;
+  }
+}
 
 export default function ServicesPage() {
   const [listings, setListings] = useState<ProductListing[]>(SERVICES);
 
+  const { data, error, isLoading } = useSWR<ProductListing[]>(
+    "/services",
+    fetchServices
+  );
+
   useEffect(() => {
-    async function load() {
-      const res = await apiClient.get('/services');
-      setListings(res.data as ProductListing[]);
+    if (data) setListings(data);
+  }, [data]);
+
+  useEffect(() => {
+    if (error) {
+      toast.error("Failed to load services. Showing sample data.");
+      setListings(SERVICES);
     }
-    load();
-  }, []);
+  }, [error]);
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setListings(prev => [...prev, generateRandomService(prev.length + 1)]);
+      setListings((prev) => [...prev, generateRandomService(prev.length + 1)]);
     }, 120000);
 
     return () => clearInterval(interval);
   }, []);
 
+  if (isLoading) {
+    return (
+      <div data-testid="loading-state" className="p-4 space-y-4">
+        <Skeleton className="h-6 w-1/3" />
+        <Skeleton className="h-[120px] w-full" />
+        <Skeleton className="h-[120px] w-full" />
+        <Skeleton className="h-[120px] w-full" />
+      </div>
+    );
+  }
+
   return (
-    <>
-      <div className="bg-zion-blue-dark py-4 px-4 md:px-8 mb-6 border-b border-zion-blue-light">
-        <div className="container mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
-          <h2 className="text-white text-lg font-medium">Featured Services</h2>
-          <div className="flex flex-wrap gap-2">
-            <Link to="/it-onsite-services">
-              <Button variant="outline" className="border-zion-purple text-zion-cyan hover:bg-zion-purple/10">
-                <Globe className="h-4 w-4 mr-2" />
-                Global IT Onsite Services
-              </Button>
-            </Link>
-            <Link to="/request-quote">
-              <Button className="bg-gradient-to-r from-zion-purple to-zion-purple-dark hover:from-zion-purple-light hover:to-zion-purple text-white">
-                Request a Quote
-              </Button>
-            </Link>
+    <ErrorBoundary>
+      <>
+        <div className="bg-zion-blue-dark py-4 px-4 md:px-8 mb-6 border-b border-zion-blue-light">
+          <div className="container mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
+            <h2 className="text-white text-lg font-medium">Featured Services</h2>
+            <div className="flex flex-wrap gap-2">
+              <Link to="/it-onsite-services">
+                <Button variant="outline" className="border-zion-purple text-zion-cyan hover:bg-zion-purple/10">
+                  <Globe className="h-4 w-4 mr-2" />
+                  Global IT Onsite Services
+                </Button>
+              </Link>
+              <Link to="/request-quote">
+                <Button className="bg-gradient-to-r from-zion-purple to-zion-purple-dark hover:from-zion-purple-light hover:to-zion-purple text-white">
+                  Request a Quote
+                </Button>
+              </Link>
+            </div>
           </div>
         </div>
-      </div>
-      <DynamicListingPage
-        title="IT & AI Services"
-        description="Find expert technology service providers for your business needs, from AI development to infrastructure management."
-        categorySlug="services"
-        listings={listings}
-        categoryFilters={SERVICE_FILTERS}
-        initialPrice={{ min: 3000, max: 10000 }}
-        itemsPerPage={10}
-      />
-      <TrustedBySection />
-    </>
+        <DynamicListingPage
+          title="IT & AI Services"
+          description="Find expert technology service providers for your business needs, from AI development to infrastructure management."
+          categorySlug="services"
+          listings={listings}
+          categoryFilters={SERVICE_FILTERS}
+          initialPrice={{ min: 3000, max: 10000 }}
+          itemsPerPage={10}
+        />
+        <TrustedBySection />
+      </>
+    </ErrorBoundary>
   );
 }
+


### PR DESCRIPTION
## Summary
- use SWR for fetching services
- display skeleton while loading
- show toast and sample listings when the services API fails
- clarify `/api/services` endpoint resolution

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6838f7a93c5c832bbc0da96e5705cf06