### PR TITLE
Replace Vite logo with placeholder company logo

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,12 +7,12 @@
   "theme_color": "#000000",
   "icons": [
     {
-      "src": "/vite.svg",
+      "src": "/logos/placeholder-logo.svg",
       "sizes": "192x192",
       "type": "image/svg+xml"
     },
     {
-      "src": "/vite.svg",
+      "src": "/logos/placeholder-logo.svg",
       "sizes": "512x512",
       "type": "image/svg+xml"
     }

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -49,7 +49,7 @@ self.addEventListener('push', event => {
   const title = data.title || 'Zion Notification';
   const options = {
     body: data.body,
-    icon: '/vite.svg'
+    icon: '/logos/placeholder-logo.svg'
   };
   event.waitUntil(self.registration.showNotification(title, options));
 });
@@ -60,7 +60,7 @@ self.addEventListener('push', event => {
   const title = data.title || 'New message';
   const options = {
     body: data.body,
-    icon: '/vite.svg',
+    icon: '/logos/placeholder-logo.svg',
     data: data.url
   };
   event.waitUntil(self.registration.showNotification(title, options));

--- a/src/components/home/ITServiceRequestHero.tsx
+++ b/src/components/home/ITServiceRequestHero.tsx
@@ -76,7 +76,7 @@ export function ITServiceRequestHero() {
         <div className="bg-zion-blue-light p-6 rounded-lg shadow-lg w-full max-w-md md:ml-auto">
           <div className="flex flex-col md:flex-row items-center gap-4">
             <Image
-              src="/vite.svg"
+              src="/logos/placeholder-logo.svg"
               alt="Technician"
               width={200}
               height={200}


### PR DESCRIPTION
## Summary
- replace Vite icon in web manifest with placeholder logo
- update service worker push icons
- swap placeholder image in IT service request hero section

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a6cdcc9ec832babcaba73c54e1d70