### PR TITLE
Implement centralized error logging

### DIFF
--- a/api/create-checkout-session.js
+++ b/api/create-checkout-session.js
@@ -1,4 +1,5 @@
 import Stripe from 'stripe';
+import { withErrorLogging } from './withErrorLogging.cjs';
 
 const PROD_DOMAIN = 'app.ziontechgroup.com';
 
@@ -11,7 +12,7 @@ function isProdDomain() {
   }
 }
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   if (req.method !== 'POST') {
     res.statusCode = 405;
     res.setHeader('Allow', 'POST');
@@ -54,3 +55,5 @@ export default async function handler(req, res) {
     res.json({ error: err.message });
   }
 }
+
+export default withErrorLogging(handler);

--- a/api/create-payment-intent.js
+++ b/api/create-payment-intent.js
@@ -1,4 +1,5 @@
 import Stripe from 'stripe';
+import { withErrorLogging } from './withErrorLogging.cjs';
 
 const PROD_DOMAIN = 'app.ziontechgroup.com';
 
@@ -11,7 +12,7 @@ function isProdDomain() {
   }
 }
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   if (req.method !== 'POST') {
     res.statusCode = 405;
     res.setHeader('Allow', 'POST');
@@ -50,3 +51,5 @@ export default async function handler(req, res) {
     res.json({ error: err.message });
   }
 }
+
+export default withErrorLogging(handler);

--- a/api/quotes.js
+++ b/api/quotes.js
@@ -1,4 +1,6 @@
-export default async function handler(req, res) {
+const { withErrorLogging } = require('./withErrorLogging.cjs');
+
+async function handler(req, res) {
   if (req.method !== 'POST') {
     res.statusCode = 405;
     res.setHeader('Allow', 'POST');
@@ -33,3 +35,4 @@ export default async function handler(req, res) {
     res.json({ error: err.message || 'Quote submission failed' });
   }
 }
+module.exports = withErrorLogging(handler);

--- a/api/subscribe.js
+++ b/api/subscribe.js
@@ -1,4 +1,6 @@
-export default async function handler(req, res) {
+const { withErrorLogging } = require('./withErrorLogging.cjs');
+
+async function handler(req, res) {
   if (req.method !== 'POST') {
     res.statusCode = 405;
     res.setHeader('Allow', 'POST');
@@ -25,3 +27,5 @@ export default async function handler(req, res) {
     res.json({ error: err.message || 'Subscription failed' });
   }
 }
+
+module.exports = withErrorLogging(handler);

--- a/api/withErrorLogging.cjs
+++ b/api/withErrorLogging.cjs
@@ -1,0 +1,19 @@
+const { captureException } = require('../src/utils/sentry');
+
+module.exports.withErrorLogging = (handler) => {
+  return async (req, res) => {
+    try {
+      return await handler(req, res);
+    } catch (err) {
+      captureException(err && err.stack ? err.stack : err);
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        if (res.json) {
+          res.json({ error: 'Internal server error' });
+        } else {
+          res.end('Internal server error');
+        }
+      }
+    }
+  };
+};

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { captureException } from '@/utils/sentry';
+
+interface ErrorPageProps {
+  statusCode?: number;
+  err?: Error;
+}
+
+export default function ErrorPage({ statusCode = 500, err }: ErrorPageProps) {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (err) {
+      captureException({
+        path: location.pathname,
+        message: err.message,
+        statusCode,
+      });
+    }
+  }, [err, location.pathname, statusCode]);
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center p-6 text-center">
+      <h1 className="text-2xl font-bold mb-4">Something went wrong</h1>
+      <p>Please try again later.</p>
+    </main>
+  );
+}

--- a/pages/api/auth/register.ts
+++ b/pages/api/auth/register.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { z } from 'zod';
+import { withErrorLogging } from '@/utils/withErrorLogging';
 
 // Generic request/response types so this file can run in Node or Next.js
 type Req = { method?: string; body?: any };
@@ -29,7 +30,7 @@ const schema = z.object({
   password: z.string().min(8, 'Password must be at least 8 characters'),
 });
 
-export default async function handler(req: Req, res: JsonRes) {
+async function handler(req: Req, res: JsonRes) {
   if (req.method !== 'POST') {
     res.status(405).end();
     return;
@@ -82,3 +83,5 @@ export default async function handler(req: Req, res: JsonRes) {
     res.status(500).json({ message: err.message || 'Registration failed' });
   }
 }
+
+export default withErrorLogging(handler);

--- a/pages/api/points/add.ts
+++ b/pages/api/points/add.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { withErrorLogging } from '@/utils/withErrorLogging';
 
 type Req = { method?: string; body?: any };
 interface JsonRes {
@@ -20,7 +21,7 @@ const serviceKey =
   '';
 const supabase = createClient(supabaseUrl, serviceKey);
 
-export default async function handler(req: Req, res: JsonRes) {
+async function handler(req: Req, res: JsonRes) {
   if (req.method !== 'POST') {
     res.status(405).end();
     return;
@@ -60,3 +61,5 @@ export default async function handler(req: Req, res: JsonRes) {
 
   res.status(200).json({ success: true });
 }
+
+export default withErrorLogging(handler);

--- a/pages/api/users/me.ts
+++ b/pages/api/users/me.ts
@@ -1,3 +1,5 @@
+import { withErrorLogging } from '@/utils/withErrorLogging';
+
 let mockUser = {
   id: '1',
   name: 'Jane Doe',
@@ -23,7 +25,7 @@ interface JsonRes {
   json: (data: any) => void;
 }
 
-export default function handler(req: Req, res: JsonRes) {
+function handler(req: Req, res: JsonRes) {
   if (req.method === 'GET') {
     res.status(200).json(mockUser);
     return;
@@ -43,3 +45,5 @@ export default function handler(req: Req, res: JsonRes) {
 
   res.status(405).end();
 }
+
+export default withErrorLogging(handler);

--- a/src/types/external-modules.d.ts
+++ b/src/types/external-modules.d.ts
@@ -349,6 +349,7 @@ declare module 'next/link' {
 declare module 'next/router' {
   interface NextRouter {
     pathname: string
+    isFallback?: boolean
   }
   export function useRouter(): NextRouter
 }

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -1,3 +1,11 @@
+let nodeSentry: any;
+try {
+  // Optional dependency for server-side logging
+  nodeSentry = require('@sentry/node');
+} catch {
+  nodeSentry = null;
+}
+
 export function captureException(error: unknown) {
   if (process.env.NODE_ENV === 'development') {
     if (typeof console !== 'undefined') {
@@ -6,6 +14,8 @@ export function captureException(error: unknown) {
   } else {
     if (typeof window !== 'undefined' && (window as any).Sentry?.captureException) {
       (window as any).Sentry.captureException(error);
+    } else if (nodeSentry?.captureException) {
+      nodeSentry.captureException(error);
     }
   }
 }

--- a/src/utils/withErrorLogging.ts
+++ b/src/utils/withErrorLogging.ts
@@ -1,0 +1,21 @@
+export type ApiHandler = (req: any, res: any) => any;
+
+import { captureException } from './sentry';
+
+export function withErrorLogging(handler: ApiHandler): ApiHandler {
+  return async (req, res) => {
+    try {
+      return await handler(req, res);
+    } catch (err: any) {
+      captureException(err?.stack ? err.stack : err);
+      if (res && !res.headersSent) {
+        res.statusCode = 500;
+        if (typeof res.json === 'function') {
+          res.json({ error: 'Internal server error' });
+        } else if (typeof res.end === 'function') {
+          res.end('Internal server error');
+        }
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- create API middleware `withErrorLogging` and use in API handlers
- add Node version for error logging middleware
- extend Sentry utility to support Node
- add application error page to log errors
- fix NextRouter stub for `isFallback`

## Testing
- `npm run test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_6839c371f394832ba9b08a59befc6202