### PR TITLE
Fix: Ensure form input text is always visible by correcting theme app…

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -21,9 +21,11 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const applyTheme = (nextTheme: Theme) => {
     const root = document.documentElement
     if (nextTheme === 'dark') {
-      root.classList.add('dark')
+      root.classList.remove('light'); // Also remove light if present
+      root.classList.add('dark');
     } else {
-      root.classList.remove('dark')
+      root.classList.remove('dark');
+      root.classList.add('light');
     }
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -6,51 +6,51 @@
   :root {
     --font-sans: 'Orbitron', system-ui, sans-serif;
 
-    --background: 0 0% 7%;
-    --foreground: 142 71% 45%;
+    --background: 0 0% 100%;
+    --foreground: 224 71% 4%;
 
-    --card: 0 0% 7%;
-    --card-foreground: 142 71% 45%;
+    --card: 0 0% 100%;
+    --card-foreground: 224 71% 4%;
 
-    --popover: 0 0% 7%;
-    --popover-foreground: 142 71% 45%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 224 71% 4%;
 
-    --primary: 216 84% 50%;
-    --primary-foreground: 0 0% 93%;
+    --primary: 262 83% 58%;
+    --primary-foreground: 210 40% 98%;
 
-    --secondary: 0 0% 68%;
-    --secondary-foreground: 0 0% 7%;
+    --secondary: 210 40% 96%;
+    --secondary-foreground: 222 47% 11%;
 
-    --muted: 0 0% 68%;
-    --muted-foreground: 215 20% 65%;
+    --muted: 210 40% 96%;
+    --muted-foreground: 215 20% 45%;
 
-    --accent: 228 12% 92%;
-    --accent-foreground: 0 0% 7%;
+    --accent: 210 40% 96%;
+    --accent-foreground: 224 71% 4%;
 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 142 71% 45%;
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 210 40% 98%;
 
-    --border: 0 0% 68%;
-    --input: 0 0% 68%;
-    --ring: 216 84% 53%;
+    --border: 214 32% 91%;
+    --input: 214 32% 91%;
+    --ring: 262 83% 58%;
 
     --radius: 0.5rem;
 
-    --sidebar-background: 228 12% 92%;
+    --sidebar-background: 210 40% 96%;
 
-    --sidebar-foreground: 0 0% 7%;
+    --sidebar-foreground: 224 71% 4%;
 
-    --sidebar-primary: 216 84% 53%;
+    --sidebar-primary: 262 83% 58%;
 
-    --sidebar-primary-foreground: 142 71% 45%;
+    --sidebar-primary-foreground: 210 40% 98%;
 
-    --sidebar-accent: 0 0% 68%;
+    --sidebar-accent: 210 40% 96%;
 
-    --sidebar-accent-foreground: 0 0% 7%;
+    --sidebar-accent-foreground: 224 71% 4%;
 
-    --sidebar-border: 0 0% 68%;
+    --sidebar-border: 214 32% 91%;
 
-    --sidebar-ring: 216 84% 53%;
+    --sidebar-ring: 262 83% 58%;
   }
 
   .dark {


### PR DESCRIPTION
…lication

The previous implementation had two issues:
1. The `:root` CSS variables in `src/index.css` defaulted to dark theme values. If no theme class (`.light` or `.dark`) was applied to the HTML element, components expecting a light background (like the Input component using `text-gray-900`) would render dark text on a dark background, making it invisible.
2. The `ThemeContext` in `src/context/ThemeContext.tsx` would remove the `.dark` class when switching to the light theme but failed to explicitly add the `.light` class.

This commit addresses these issues by:
1. Modifying `src/index.css` to set the `:root` CSS variables to the light theme values. This ensures a safe default if theme classes are not yet applied or are missing.
2. Updating `ThemeContext.tsx` to explicitly add `.light` when the theme is light and `.dark` when the theme is dark to `document.documentElement`, ensuring the correct theme classes are always present.

These changes guarantee that form inputs will have appropriate text-to-background contrast in all theme states (default, light, and dark).